### PR TITLE
Fix option greeks greater 1

### DIFF
--- a/src/incoming.ts
+++ b/src/incoming.ts
@@ -1266,13 +1266,13 @@ Incoming.prototype._TICK_OPTION_COMPUTATION = function () {
   var tickType = this.dequeueInt();
   var impliedVol = this.dequeueFloat();
 
-  if (impliedVol < 0) {  // -1 is the "not yet computed" indicator
+  if (impliedVol == -1) {  // -1 is the "not yet computed" indicator
     impliedVol = Number.MAX_VALUE;
   }
 
   var delta = this.dequeueFloat();
 
-  if (Math.abs(delta) > 1) {  // -2 is the "not yet computed" indicator
+  if (delta == -2) {  // -2 is the "not yet computed" indicator
     delta = Number.MAX_VALUE;
   }
 
@@ -1286,13 +1286,13 @@ Incoming.prototype._TICK_OPTION_COMPUTATION = function () {
   if (version >= 6 || tickType === C.TICK_TYPE.MODEL_OPTION) {  // introduced in version == 5
     optPrice = this.dequeueFloat();
 
-    if (optPrice < 0) {  // -1 is the "not yet computed" indicator
+    if (optPrice == -1) {  // -1 is the "not yet computed" indicator
       optPrice = Number.MAX_VALUE;
     }
 
     pvDividend = this.dequeueFloat();
 
-    if (pvDividend < 0) {  // -1 is the "not yet computed" indicator
+    if (pvDividend == -1) {  // -1 is the "not yet computed" indicator
       pvDividend = Number.MAX_VALUE;
     }
   }
@@ -1300,25 +1300,25 @@ Incoming.prototype._TICK_OPTION_COMPUTATION = function () {
   if (version >= 6) {
     gamma = this.dequeueFloat();
 
-    if (Math.abs(gamma) > 1) {  // -2 is the "not yet computed" indicator
+    if (gamma == -2) {  // -2 is the "not yet computed" indicator
       gamma = Number.MAX_VALUE;
     }
 
     vega = this.dequeueFloat();
 
-    if (Math.abs(vega) > 1) {  // -2 is the "not yet computed" indicator
+    if (vega == -2) {  // -2 is the "not yet computed" indicator
       vega = Number.MAX_VALUE;
     }
 
     theta = this.dequeueFloat();
 
-    if (Math.abs(theta) > 1) {  // -2 is the "not yet computed" indicator
+    if (theta == -2) {  // -2 is the "not yet computed" indicator
       theta = Number.MAX_VALUE;
     }
 
     undPrice = this.dequeueFloat();
 
-    if (undPrice < 0) {  // -1 is the "not yet computed" indicator
+    if (undPrice == -1) {  // -1 is the "not yet computed" indicator
       undPrice = Number.MAX_VALUE;
     }
   }


### PR DESCRIPTION
Option greeks what values greater than 1 do not work properly as they are limited to 1 and if greater, it will be set Number.MAX_VALUE.
This is not on sync with Java implementation and causes the issue that values greater 1 cannot be displayed, as they are Number.MAX_VALUE.

This PR is about to fix this issue and align the Typescript code to what Java code is doing.