### PR TITLE
Add support for ts-node-dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to dev:debug",
+      "protocol": "inspector",
+      "port": 9222,
+      "restart": true,
+      "cwd": "${workspaceRoot}"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "dev:debug",
+			"problemMatcher": [],
+			"label": "dev: debug",
+			"detail": "devleopment debug build",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"isBackground": true,
+		}
+	]
+}

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,0 +1,43 @@
+
+
+function run() {
+
+  var util = require('util');
+
+  var chalk = require('chalk');
+
+  var ib = new (require("../src/index"))({
+    clientId: 0,
+    host: "localhost",
+    port: 4001
+  }).on('connected', function () {
+    console.log(chalk.inverse('CONNECTED'));
+  }).on('disconnected', function () {
+    console.log(chalk.inverse('DISCONNECTED'));
+  }).on('received', function (tokens) {
+    console.info('%s %s', chalk.cyan('<<< RECV <<<'), JSON.stringify(tokens));
+  }).on('sent', function (tokens) {
+    console.info('%s %s', chalk.yellow('>>> SENT >>>'), JSON.stringify(tokens));
+  }).on('server', function (version, connectionTime) {
+    console.log(chalk.inverse(util.format('Server Version: %s', version)));
+    console.log(chalk.inverse(util.format('Server Connection Time: %s', connectionTime)));
+  }).on('error', function (err) {
+    console.error(chalk.red(util.format('@@@ ERROR: %s @@@', err.message)));
+  }).on('result', function (event, args) {
+    console.log(chalk.green(util.format('======= %s =======', event)));
+    args.forEach(function (arg, i) {
+      console.log('%s %s',
+        chalk.green(util.format('[%d]', i + 1)),
+        JSON.stringify(arg)
+      );
+    });
+  });
+
+  ib.connect();
+}
+
+
+// wait 2s before running the code, to give the debugger some time to attach (so we won't miss any breakpoints at the very beginning.)
+setTimeout(() => {
+  run();
+}, 2000);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "lint": "tslint \"src/**/*.ts\" --project tsconfig.json",
     "build": "rimraf dist && tsc -p .",
     "prepare": "npm run build",
+    "dev": "ts-node-dev --respawn --transpile-only examples/index.ts",
+    "dev:debug": "ts-node-dev --inspect=9222 --respawn --transpile-only examples/index.ts",
     "doc": "typedoc src"
   },
   "engines": {
@@ -71,6 +73,7 @@
     "mocha": "^7.1.1",
     "rimraf": "^2.7.1",
     "ts-node": "^8.4.1",
+    "ts-node-dev": "^1.1.1",
     "tslint": "^5.11.0",
     "tslint-config-standard": "^8.0.1",
     "typedoc": "^0.19.2",


### PR DESCRIPTION
This PR does not affect any functionality on the library, but it will make lazy-developer live easier.
The the changes:
- Adds a new dependency to ts-node-dev. This is tool that monitors all ts code files and if it something change, it does a re-transpile / restart the build process.  Also added a VSCode build task, so you can start it with Shift+Ctrl+B.
- Added a new 'dev' script. 
"npm run dev" will start the ts-node-dev. So you can start to write code and each time you save the changes, it will re-build.
- Added a new 'dev:debug' script. 
This will attach the debugger to the ts-node-dev. Also added a VSCode launch task, so you can run it with F5.

Background: the example folder will get *.ts files in parallel to the existing *.js files, which provide Typescript sample code, but more important, provides some smoke-test I can run to see if it all still works.

Typical dev workflow after those changes:
- Press Shirt+Ctrl+B to start the build and run the example/index.ts via ts-node-dev. If you change code, ts-node-dev will notice, re-transpile and re-start example/index.ts automatically.
- Press F5 to attach the debugger. Use F9/F10.. keys as usual to debug through the code.

Not sure if it is worth mentioning on the readme.md
It is only useful for library developers, library  users won't rally have use-case where they want to run ib lib on ts-node-dev (their rather install it via npm).


