### PR TITLE
Change ContractDetails.underSecType from string type to SecType.

### DIFF
--- a/src/api/contract/contractDetails.ts
+++ b/src/api/contract/contractDetails.ts
@@ -1,5 +1,5 @@
 import { TagValue } from "../api";
-import { Contract } from "./contract";
+import { Contract, SecType } from "./contract";
 
 /**
  * Extended contract details.
@@ -134,7 +134,7 @@ export interface ContractDetails {
  	underSymbol?: string;
 
   /**	For derivatives, returns the underlying security type. */
- 	underSecType?: string;
+ 	underSecType?: SecType;
 
   /** The list of market rule IDs separated by comma Market rule IDs can be used to determine the minimum price increment at a given price. */
  	marketRuleIds?: string;

--- a/src/io/decoder.ts
+++ b/src/io/decoder.ts
@@ -777,7 +777,7 @@ export class Decoder {
 
       if (this.serverVersion >= MIN_SERVER_VER.UNDERLYING_INFO) {
         contract.underSymbol = this.readStr();
-        contract.underSecType = this.readStr();
+        contract.underSecType = this.readStr() as SecType;
       }
 
       if (this.serverVersion >= MIN_SERVER_VER.MARKET_RULES) {


### PR DESCRIPTION
ContractDetails.underSecType is string type on current API, but actually we have a SecType enum for that - changed it.