### PR TITLE
Improve robustness against decoding errors when using V100 protocol.

### DIFF
--- a/src/io/controller.ts
+++ b/src/io/controller.ts
@@ -95,10 +95,22 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
 
   /**
    * Called when a message has been arrived on the API server connection.
+   *
+   * Used on V100 protocol.
    */
   onMessage(tokens: string[]): void {
-    this.decoder.enqueue(tokens);
+    this.decoder.enqueueMessage(tokens);
   }
+
+  /**
+   * Called when a message has been arrived on the API server connection.
+   *
+   * Used on pre-V100 protocol.
+   */
+  onTokens(tokens: string[]): void {
+    this.decoder.enqueueTokens(tokens);
+  }
+
 
   /**
    * Get the API server version.
@@ -225,23 +237,6 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
       this.emitError("Cannot disconnect if already disconnected.", ErrorCode.NOT_CONNECTED, -1);
     }
   }
-
-  /**
-   * Send an API command to the server connection.
-   *
-   * @param funcName API function name.
-   * @param funcName API arguments.
-   *
-   * @see [[api]]
-   */
-  /*
-  private executeApi(funcName: string, args: unknown[]): void {
-    if (this.encoder[funcName] instanceof Function) {
-      this.encoder[funcName](args);
-    } else {
-      throw new Error("Unknown outgoing func - " + funcName);
-    }
-  }*/
 
   /**
    * Send raw token data to the server connection.

--- a/src/io/socket.ts
+++ b/src/io/socket.ts
@@ -194,7 +194,7 @@ export class Socket {
   }
 
   /**
-   * Called when a message has been arrived.
+   * Called when new tokens have been received from server.
    */
   private onMessage(data: string): void {
 
@@ -226,7 +226,11 @@ export class Socket {
 
       // post to queue
 
-      this.controller.onMessage(tokens);
+      if (this.useV100Plus) {
+        this.controller.onMessage(tokens);
+      } else {
+        this.controller.onTokens(tokens);
+      }
 
       // process queue
 


### PR DESCRIPTION
While issue https://github.com/stoqey/ib/issues/23 is fixed, it showed two additional issues that are addressed by this PR:

1) The V100 allows to check for message boundaries. It sends the length of the message, followed by the tokens.
So we can verify if a decoder function actually did read all token it actually needs to read. Also we can drain any remaining any remaining tokens up next message start, so that decoding of other messages continues to to work, also if one decoder function is buggy.
Also we can verify if a decoder function tries to read past the message boundary and stop it form doing so.

2) There no useful error output at all if a decoding error happens - did improve that.
For testing purpose I did modify decodeMsg_POSITION to read one token than is it should. Decoding of all other messages does continue, but you will get an error event with:
Error: Underrun error on decodeMsg_POSITION: End of message reached. Please report to https://github.com/stoqey/ib
    at Controller.emitError (C:\srcmfr\ib\src\io\controller.ts:202:37)
    at Decoder.process (C:\srcmfr\ib\src\io\decoder.ts:285:25)
    at Controller.processIngressQueue (C:\srcmfr\ib\src\io\controller.ts:93:18)
    at Socket.onMessage (C:\srcmfr\ib\src\io\socket.ts:237:23)
    at Socket.onData (C:\srcmfr\ib\src\io\socket.ts:189:14)
    at Socket.<anonymous> (C:\srcmfr\ib\src\io\socket.ts:108:32)
    at Socket.emit (events.js:210:5)
    at addChunk (_stream_readable.js:309:12)
    at readableAddChunk (_stream_readable.js:290:11)
    at Socket.Readable.push (_stream_readable.js:224:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:182:23)
If the functions reads less tokens than it should, decoding of all other messages also continues to work and the error event is:
Error: Decoding error on decodeMsg_POSITION: unprocessed data left on queue. Please report to https://github.com/stoqey/ib
    at Controller.emitError (C:\srcmfr\ib\src\io\controller.ts:202:37)
    at Decoder.process (C:\srcmfr\ib\src\io\decoder.ts:271:27)
    at Controller.processIngressQueue (C:\srcmfr\ib\src\io\controller.ts:93:18)
    at Socket.onMessage (C:\srcmfr\ib\src\io\socket.ts:237:23)
    at Socket.onData (C:\srcmfr\ib\src\io\socket.ts:189:14)
    at Socket.<anonymous> (C:\srcmfr\ib\src\io\socket.ts:108:32)
	
