### PR TITLE
- Fix placeOrder on server version >= 103

### DIFF
--- a/src/io/encoder.ts
+++ b/src/io/encoder.ts
@@ -1180,6 +1180,10 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
       tokens.push(order.faProfile);
     }
 
+    if (this.serverVersion >=MIN_SERVER_VER.MODELS_SUPPORT) {
+      tokens.push(order.modelCode);
+    }
+
     if (this.serverVersion >= 18) {
       // institutional short sale slot fields.
       tokens.push(order.shortSaleSlot); // 0 only for retail, 1 or 2 only for institution.

--- a/src/io/socket.ts
+++ b/src/io/socket.ts
@@ -164,6 +164,8 @@ export class Socket {
       }
 
       this.client?.write(new Uint8Array(utf8Data));
+    } else {
+      this.client?.write(stringData + EOL);
     }
 
     this.controller.emitEvent(EventName.sent, tokens, stringData);
@@ -305,7 +307,8 @@ export class Socket {
 
     // send client version (unless Version > 100)
     if (!this.useV100Plus) {
-      this.send([Config.CLIENT_VERSION]);  // Do not add length prefix here, because Server does not know Client's version yet
+      this.send([Config.CLIENT_VERSION]);
+      this.send([this.options.clientId]);
     } else {
       // Switch to GW API (Version 100+ requires length prefix)
       const config = this.buildVersionString(MIN_VERSION_V100, MAX_SUPPORTED_SERVER_VERSION);


### PR DESCRIPTION
As found on https://github.com/stoqey/ib/issues/29 this PR fixes the placeOrder on server version >= 103 (change on encoder)

While testing it and trying if works on old server version, I noticed that pre-V100 mode is broken all together, fixed as well (change on socket)
