### PR TITLE
Switch from EventEmitter to EventEmitter3

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.16.0",
     "eslint-plugin-jest": "^24.1.3",
+    "eventemitter3": "^4.0.7",
     "function-rate-limit": "^1.1.0",
     "jest": "^26.6.3",
     "jest-environment-node": "^26.6.2",

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from "eventemitter3";
 import { Controller } from "../io/controller";
 import { Contract, SecType } from "./contract/contract";
 import { Order } from "./order/order";


### PR DESCRIPTION
During working on IBApiNext I have noticed the following message on console:
(node:2620) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 pnlSingle listeners added to [IBApi]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)

Reason is that node EventEmitter assumes that there is a memory leak if there are more than 10 listeners on an EventEmitter.
However, for us however this is a normal quite usecase.  Example: I want PnL of every position, so I do reqPnLSingle for every position and might want to have a pnlSingle event handler for every position as well - which will lead to this warning if you have more than 11 positions.

The warning does not seem to have any real effect, still it anoying.
Changed from node EventEmitter to EventEmitter3 to solve that. EventEmitter3 does not output this warning anymore (and also is performant than EventEmitter)