### PR TITLE
Handle Partial Data

### DIFF
--- a/src/io/socket.ts
+++ b/src/io/socket.ts
@@ -74,6 +74,7 @@ export class Socket {
   /** `true` if V!00Pls protocol shall be used, `false` otherwise.  */
   private useV100Plus = true;
 
+  /** Accumulation buffer for fragmented V100 messages */
   private _v100MessageBuffer: Buffer = Buffer.alloc(0);
 
   /** Returns `true` if connected to TWS/IB Gateway, `false` otherwise.  */


### PR DESCRIPTION
This is a draft pull request to handle partial data being received on the IB connection socket.

The data parsing method appears to previously have been biased to assume that each call of the event handler would have a full and complete response from the IB server. However, that does not correctly handle cases where the socket might have buffered data from multiple calls ( or any other number of scenarios where the data received is partial ) and require that prior data that was received may in fact be part of a valid-yet-not-complete send on the part of the gateway / TWS.

This PR:

* Buffers data from previous calls and attempts to dispatch messages as they become fully formed
* Only buffer the data that has not yet been fully read
* Handle cases where the data parsing exceeds what the max message size might be, and panic ( as best possible )

My rationale for panic was that every effort should be taken to prevent a case where a physically-valid-but-logically-incorrect packet might be dispatched to a receiver. 

No tests currently because I am not quite certain how the testing process is done w/ this lib. PR'ing now for review / any possible discussion.