### PR TITLE
Add clientId argument to IBApi.connect function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ ib.reqPositions();
 This library was initialiity forked from a JScript project (https://github.com/pilwon/node-ib) and ported to Typescript.
 The API interfaces are still largly compatible with the old library, however there are ongoing efforts port this library to more modern Typescript-like codebase and interface design.
 
-Therefore there is defined deprication process:<br/>
+Therefore there is defined deprecation process:<br/>
 
-Public interfaces, that are planned to be remmoved, will be marked with a @deprecated. <br/>
+Public interfaces, that are planned to be removed, will be marked with a @deprecated. <br/>
 The @deprecated tag will contain a description or link on how migrate to new API (example: IBApiCreationOptions.clientId).<br/>
 VSCode will explicitly mark deprecated functions and attributes, so you cannot miss it.<br/>
 

--- a/README.md
+++ b/README.md
@@ -78,18 +78,20 @@ ib.connect();
 ib.reqPositions();
 ```
 
-## Roadmap and Depreciation process
+## and Depreciation process
 
 This library was initialiity forked from a JScript project (https://github.com/pilwon/node-ib) and ported to Typescript.
 The API interfaces are still largly compatible with the old library, however there are ongoing efforts port this library to more modern Typescript-like codebase and interface design.
 
 Therefore there is defined deprication process:<br/>
+
 Public interfaces, that are planned to be remmoved, will be marked with a @deprecated. <br/>
 The @deprecated tag will contain a description or link on how migrate to new API (example: IBApiCreationOptions.clientId).<br/>
 VSCode will explicitly mark deprecated functions and attributes, so you cannot miss it.<br/>
+
 If you write new code, don't use deprecated functions.<br/>
-If you use deprecated functions on existing code, migrate to new on your next code-clean up session. There is no need for immediate change, the deprecated function will continue to work
-for a least a hlaf more year, but at some point it will be removed.<br/>
+If you already use deprecated functions on existing code, migrate to new function on your next code-clean up session. There is no need for immediate change, the deprecated function will 
+continue to work for a least a half more year, but at some point it will be removed.<br/>
 
 
 ## How to contribute

--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ ib.connect();
 ib.reqPositions();
 ```
 
+## Roadmap and Depreciation process
+
+This library was initialiity forked from a JScript project (https://github.com/pilwon/node-ib) and ported to Typescript.
+The API interfaces are still largly compatible with the old library, however there are ongoing efforts port this library to more modern Typescript-like codebase and interface design.
+
+Therefore there is defined deprication process:<br/>
+Public interfaces, that are planned to be remmoved, will be marked with a @deprecated. <br/>
+The @deprecated tag will contain a description or link on how migrate to new API (example: IBApiCreationOptions.clientId).<br/>
+VSCode will explicitly mark deprecated functions and attributes, so you cannot miss it.<br/>
+If you write new code, don't use deprecated functions.<br/>
+If you use deprecated functions on existing code, migrate to new on your next code-clean up session. There is no need for immediate change, the deprecated function will continue to work
+for a least a hlaf more year, but at some point it will be removed.<br/>
+
+
 ## How to contribute
 
 IB does regularly release new API versions, so this library will need permanent maintenance in oder to stay up-to-date with latest TWS features.<br/>

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ ib.connect();
 ib.reqPositions();
 ```
 
-## Depreciation process
+## Deprecation process
 
 This library was initialiity forked from a JScript project (https://github.com/pilwon/node-ib) and ported to Typescript.
 The API interfaces are still largly compatible with the old library, however there are ongoing efforts port this library to more modern Typescript-like codebase and interface design.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ ib.connect();
 ib.reqPositions();
 ```
 
-## and Depreciation process
+## Depreciation process
 
 This library was initialiity forked from a JScript project (https://github.com/pilwon/node-ib) and ported to Typescript.
 The API interfaces are still largly compatible with the old library, however there are ongoing efforts port this library to more modern Typescript-like codebase and interface design.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ ib.reqPositions();
 This library was initialiity forked from a JScript project (https://github.com/pilwon/node-ib) and ported to Typescript.
 The API interfaces are still largly compatible with the old library, however there are ongoing efforts port this library to more modern Typescript-like codebase and interface design.
 
-Therefore there is defined deprecation process:<br/>
+Therefore there is a defined deprecation process:<br/>
 
 Public interfaces, that are planned to be removed, will be marked with a @deprecated. <br/>
 The @deprecated tag will contain a description or link on how migrate to new API (example: IBApiCreationOptions.clientId).<br/>

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -50,6 +50,9 @@ export interface IBApiCreationOptions {
    * A unique client id (per TWS or IB Gateway instance).
    *
    * Default is 0.
+   *
+   * @deprecated The attributes should not be used anymore.
+   * Use clientId argument [[IBApi.connect]] instead.
    */
   clientId?: number;
 }
@@ -97,6 +100,9 @@ export class IBApi extends EventEmitter {
 
   /**
    * Allows to switch between different current (V100+) and previous connection mechanisms.
+   *
+   * @deprecated pre-V100 support will be removed. Please consider updating your
+   * TWS and/or IB Gateway version.
    */
   disableUseV100Plus(): void {
     return this.controller.disableUseV100Plus();
@@ -104,9 +110,12 @@ export class IBApi extends EventEmitter {
 
   /**
    * Connect to the TWS or IB Gateway.
+   *
+   * @param clientId A unique client id (per TWS or IB Gateway instance).
+   * When not specified, the client id from [[IBApiCreationOptions]] or the default client id (0) will used.
    */
-  connect(): IBApi {
-    this.controller.connect();
+  connect(clientId?: number): IBApi {
+    this.controller.connect(clientId);
     return this;
   }
 

--- a/src/io/controller.ts
+++ b/src/io/controller.ts
@@ -52,8 +52,8 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
   /**
    * Connect to the API server.
    */
-  connect(): void {
-    this.commands.schedule(() => this.executeConnect());
+  connect(clientId?: number): void {
+    this.commands.schedule(() => this.executeConnect(clientId));
   }
 
   /**
@@ -216,9 +216,9 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
    *
    * @see [[connect]]
    */
-  private executeConnect(): void {
+  private executeConnect(clientId?: number): void {
     if (!this.socket.connected) {
-      this.socket.connect();
+      this.socket.connect(clientId);
     } else {
       this.emitError(
         "Cannot connect if already connected.",


### PR DESCRIPTION
I have some auto-reconnect code in my project which will re-connect if there is no more response for some time. Sometimes (when I force connection drop), TWS does not notice the lost connection immediately and so there still is an active session for my client id ad TWS reject the re-connect (ID already exists).
Therefor I would like to use new client id on ever re-connect, but right now this is not possible w/o re-creating the whole IBApi object. So solve that, IBApi.connect now has a an (optional) clientId argument and IBApiCreationOptions.clientId has been deprecated.

I have also added some information about the "Deprecation Process" on readme. 
Basically, if we want to get rid of something we add "@depricated" to give users some time to migrate and after some more time remove it.

All changes:
- Add clientId argument id IBApi.connect function
- Deprecate IBApiCreationOptions.clientId
- Deprecate IBApi.disableUseV100Plus
- Add information about deprecation process to README.md
- Updated doc