### PR TITLE
Fix historical data

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2381,8 +2381,6 @@ export declare interface IBApi {
    * WAP: weighted average price
    * The time zone of the bar is the time zone chosen on the TWS login screen.
    * Smallest bar size is 1 second.
-   * The time zone of the bar is the time zone chosen on the TWS login screen.
-   * Smallest bar size is 1 second.
    *
    * @see [[reqHistogramData]]
    */

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "eventemitter3";
-
 import { Controller } from "../io/controller";
 import { Contract } from "./contract/contract";
 import { ContractDescription } from "./contract/contractDescription";
@@ -15,14 +14,13 @@ import LogLevel from "./data/enum/log-level";
 import MIN_SERVER_VER from "./data/enum/min-server-version";
 import OptionExerciseAction from "./data/enum/option-exercise-action";
 import { ErrorCode } from "./errorCode";
-import { Bar } from "./historical/bar";
 import { HistogramEntry } from "./historical/histogramEntry";
 import { HistoricalTick } from "./historical/historicalTick";
 import { HistoricalTickBidAsk } from "./historical/historicalTickBidAsk";
 import { HistoricalTickLast } from "./historical/historicalTickLast";
 import { ScannerSubscription } from "./market/scannerSubscription";
-import { TickType } from "./market/tickType";
 import { TickByTickDataType } from "./market/tickByTickDataType";
+import { TickType } from "./market/tickType";
 import { Order } from "./order/order";
 import { OrderState } from "./order/orderState";
 import { CommissionReport } from "./report/commissionReport";
@@ -2332,13 +2330,35 @@ export declare interface IBApi {
    * @param listener
    * reqId:	the request's identifier
    *
-   * bar: the OHLC historical data [[Bar]].
+   * time: the time the bar represents
+   * open: price at open of time period
+   * high: high price during time period
+   * low: low price during time period
+   * close: price at close of time period
+   * volume: share volume during time period
+   * count: trade count during time period
+   * WAP: weighted average price
+   * hasGaps: identifies whether or not there are gaps in the data.
    * The time zone of the bar is the time zone chosen on the TWS login screen.
    * Smallest bar size is 1 second.
+   *
+   * @see https://interactivebrokers.github.io/tws-api/historical_bars.html#hd_what_to_show
+   * for additional context regarding meaning of price for different bar types
    */
   on(
     event: EventName.historicalData,
-    listener: (reqId: number, bar: Bar) => void
+    listener: (
+      reqId: number,
+      time: string,
+      open: number,
+      high: number,
+      low: number,
+      close: number,
+      volume: number,
+      count: number,
+      WAP: number,
+      hasGaps: boolean | undefined
+    ) => void
   ): this;
 
   /**
@@ -2351,7 +2371,16 @@ export declare interface IBApi {
    * @param listener
    * reqId: The request's identifier.
    *
-   * bar: The OHLC historical data Bar.
+   * time: the time the bar represents
+   * open: price at open of time period
+   * high: high price during time period
+   * low: low price during time period
+   * close: price at close of time period
+   * volume: share volume during time period
+   * count: trade count during time period
+   * WAP: weighted average price
+   * The time zone of the bar is the time zone chosen on the TWS login screen.
+   * Smallest bar size is 1 second.
    * The time zone of the bar is the time zone chosen on the TWS login screen.
    * Smallest bar size is 1 second.
    *
@@ -2361,7 +2390,14 @@ export declare interface IBApi {
     event: EventName.historicalDataUpdate,
     listener: (
       reqId: number,
-      bar: unknown /* TODO: replace with Bar type as soon as available. */
+      time: string,
+      open: number,
+      high: number,
+      low: number,
+      close: number,
+      volume: number,
+      count: number,
+      WAP: number
     ) => void
   ): this;
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3625,43 +3625,4 @@ export declare interface IBApi {
       origExchange: string
     ) => void
   ): this;
-
-  /**
-   * Receives the subscribed account's portfolio.
-   * This function will receive only the portfolio of the subscribed account.
-   *
-   * If the portfolios of all managed accounts are needed, refer to [[reqPosition]].
-   *
-   * After the initial callback to updatePortfolio, callbacks only occur for positions which have changed.
-   *
-   * @param listener
-   * contract:The [[Contract]] for which a position is held.
-   *
-   * position: The number of positions held.
-   *
-   * marketPrice: The instrument's unitary price.
-   *
-   * marketValue: The total market value of the instrument.
-   *
-   * averageCost: The average acquiring cost.
-   *
-   * unrealizedPNL: The unrealized PnL.
-   *
-   * realizedPNL: The realized PnL.
-   *
-   * accountName : The account name.
-   */
-  on(
-    event: EventName.updateNewsBulletin,
-    listener: (
-      contract: Contract,
-      position: number,
-      marketPrice: number,
-      marketValue: number,
-      averageCost: number,
-      unrealizedPNL: number,
-      realizedPNL: number,
-      accountName: number
-    ) => void
-  ): this;
 }

--- a/src/io/decoder.ts
+++ b/src/io/decoder.ts
@@ -1085,7 +1085,10 @@ export class Decoder {
       const close = this.readDouble();
       const volume = this.readInt();
       const WAP = this.readDouble();
-      const hasGaps = this.readBool();
+      let hasGaps: boolean | undefined = undefined;
+      if (this.serverVersion < MIN_SERVER_VER.SYNT_REALTIME_BARS) {
+        hasGaps = this.readBool();
+      }
 
       let barCount = -1;
       if (version >= 3) {

--- a/src/io/decoder.ts
+++ b/src/io/decoder.ts
@@ -104,6 +104,7 @@ enum IN_MSG_ID {
   HISTORICAL_NEWS_END = 87,
   HEAD_TIMESTAMP = 88,
   HISTOGRAM_DATA = 89,
+  HISTORICAL_DATA_UPDATE = 90,
   PNL = 94,
   PNL_SINGLE = 95,
   HISTORICAL_TICKS = 96,
@@ -1123,6 +1124,33 @@ export class Decoder {
       -1,
       -1,
       false
+    );
+  }
+
+  /**
+   * Decode a HISTORICAL_DATA_UPDATE message from data queue and emit historicalDataUpdate events.
+   */
+  private decodeMsg_HISTORICAL_DATA_UPDATE(): void {
+    const reqId = this.readInt();
+    const barCount = this.readInt();
+    const date = this.readStr();
+    const open = this.readDouble();
+    const close = this.readDouble();
+    const high = this.readDouble();
+    const low = this.readDouble();
+    const WAP = this.readDouble();
+    const volume = this.readInt();
+    this.emit(
+      EventName.historicalDataUpdate,
+      reqId,
+      date,
+      open,
+      high,
+      low,
+      close,
+      volume,
+      barCount,
+      WAP
     );
   }
 

--- a/src/io/encoder.ts
+++ b/src/io/encoder.ts
@@ -1952,11 +1952,13 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
       }
     }
 
-    const tokens: unknown[] = [
-      OUT_MSG_ID.REQ_HISTORICAL_DATA,
-      version,
-      tickerId,
-    ];
+    const tokens: unknown[] = [OUT_MSG_ID.REQ_HISTORICAL_DATA];
+
+    if (this.serverVersion < MIN_SERVER_VER.SYNT_REALTIME_BARS) {
+      tokens.push(version);
+    }
+
+    tokens.push(tickerId);
 
     // send contract fields
     if (this.serverVersion >= MIN_SERVER_VER.TRADING_CLASS) {


### PR DESCRIPTION
This PR addresses issues w/ the `reqHistoricalData` method

It:

* Fixes an issue where the client incorrectly sent a `version` with the initial request. This should only happen when the server version is `< 124`, as per the Java client
* Only check and for attempt to read the `hasGaps` token if the server is sending it ( as above, if the version is `< 124` ). Note that the Java client outright discards this value, but here it is maintained
* Add support to the decoder for actually processing real time updates as they are received rather than erroring / dropping them
* Fix the typings for the `reqHistoricalData` and historical data real time event listeners. Previously they stated that they would receive an `IB.Bar` object; this is incorrect. They will instead be called with arguments matching the tokens that were received in the update event.
* Remove a duplicate typing in `api.ts` that appears to have incorrectly been left in