### PR TITLE
Fix completed orders

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2042,11 +2042,7 @@ export declare interface IBApi {
    */
   on(
     event: EventName.completedOrder,
-    listener: (
-      contract: Contract,
-      order: unknown /* TODO: replace with Order type as soon as available. */,
-      orderState: unknown /* TODO: replace with	OrderState type as soon as available. */
-    ) => void
+    listener: (contract: Contract, order: Order, orderState: OrderState) => void
   ): this;
 
   /**

--- a/src/io/decoder.ts
+++ b/src/io/decoder.ts
@@ -2617,7 +2617,7 @@ export class Decoder {
   /**
    * Decode a COMPLETED_ORDER_END message from data queue and a emit completedOrdersEnd event.
    */
-  private decodeMsg_COMPLETED_ORDER_END(): void {
+  private decodeMsg_COMPLETED_ORDERS_END(): void {
     this.emit(EventName.completedOrdersEnd);
   }
 

--- a/src/io/decoder.ts
+++ b/src/io/decoder.ts
@@ -2596,6 +2596,10 @@ export class Decoder {
       order.cashQty = this.readDoubleMax();
     }
 
+    if (this.serverVersion >= MIN_SERVER_VER.AUTO_PRICE_FOR_HEDGE) {
+      order.dontUseAutoPriceForHedge = this.readBool();
+    }
+
     if (this.serverVersion >= MIN_SERVER_VER.ORDER_CONTAINER) {
       order.isOmsContainer = this.readBool();
     }


### PR DESCRIPTION
This PR fixes a few issues with `reqCompletedOrders`:

* The typing on the completed order listener is adjusted to reflect the fact that the decoder does in fact provide a `Contract`, `Order` and `OrderState` object
* The completed order decoder has been adjusted to accommodate the presence of a `dontUseAutoPriceForHedge` field present for specific client / server pairings
* A typo is fixed to allow for the `COMPLETED_ORDERS_END` event to be handled correctly