### PR TITLE
Allow calls before connected

### DIFF
--- a/src/io/controller.ts
+++ b/src/io/controller.ts
@@ -21,6 +21,7 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
    */
   constructor(private ib: IBApi, private options?: IBApiCreationOptions) {
     this.socket = new Socket(this, this.options);
+    this.commands.pause();
   }
 
   /** The API socket object. */
@@ -53,14 +54,14 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
    * Connect to the API server.
    */
   connect(clientId?: number): void {
-    this.commands.schedule(() => this.executeConnect(clientId));
+    this.executeConnect(clientId);
   }
 
   /**
    * Disconnect from the API server.
    */
   disconnect(): void {
-    this.commands.schedule(() => this.executeDisconnect());
+    this.executeDisconnect();
   }
 
   /**


### PR DESCRIPTION
Up to now it was required to call api.connect(), wait for the EventName.connected and then it was possible to call API functions w/o getting an error.
This is because all commands, including connect, are posted into the command-queue, which is in running-mode right from the beginning. So you call reqSomething, command will dispatch into encoder and encoder will error because it doesn't know server yet (and even it would, there is no TCP connection on the socket yet).
We can solve that easily by starting up command queue in pause-mode and not posting connect/disconnect to queue but to socket directly. So you can call reqSomething, wich will wait on command queue until command processing is started, which is after the connect() completed the API-init handshake (so encoder has a server version is ready to send the reqSomething to TWS now).