### PR TITLE
Add missing primaryExch token to reqMktDepth

### DIFF
--- a/src/io/encoder.ts
+++ b/src/io/encoder.ts
@@ -2360,6 +2360,11 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
     }
 
     tokens.push(contract.exchange);
+
+    if (this.serverVersion >= MIN_SERVER_VER.MKT_DEPTH_PRIM_EXCHANGE) {
+      tokens.push(contract.primaryExch);
+    }
+
     tokens.push(contract.currency);
     tokens.push(contract.localSymbol);
 


### PR DESCRIPTION
The `primaryExch` field seems to be missing from `reqMktDepth` which is causing the API to hang.

This should fix it.