### PR TITLE
Enforce rate limit if not configured from external

### DIFF
--- a/src/core/io/controller.ts
+++ b/src/core/io/controller.ts
@@ -143,7 +143,7 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
    * Can contain nested arrays.
    */
   sendMsg(...tokens: unknown[]): void {
-    rateLimit(configuration.max_req_per_second, 1000, () => {
+    rateLimit(configuration.max_req_per_second ?? 40, 1000, () => {
       this.socket.send(tokens);
     })();
   }


### PR DESCRIPTION
When max_req_per_second is not set on config, we do not enforce any rate limit. 
This can cause IB Gateway to hang up if the App sends out too many requests simultaneously. 
This change enforces a 40 message per second limit (official TWS limit is 50).

This is only is a simply send [n] chunks than wait for the rest of the second algorithm, so it send a burst of messages first and than it wait for next tick.
I will keep a close eye on it to see if still get those Gateway hangs - if yes, we might need to add a traffic-shaping to get rid of the msg-burst and distributed packages evenly across the send-timeframe... but up to now it looks ok. No more hangs when I push my 100 market data requests into the API all at once.