### PR TITLE
Various IBApiNext improvments.

### DIFF
--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -5,7 +5,6 @@ import LogLevel from "../api/data/enum/log-level";
 import {
   AccountSummaryValue,
   ConnectionState,
-  IBApiAutoConnection,
   IBApiNextError,
   IBApiTickType,
   MarketDataTick,
@@ -31,6 +30,7 @@ import {
 import { MutableAccountPositions } from "../core/api-next/api/position/mutable-account-positions-update";
 import { MutableMarketData } from "../core/api-next/api/market/mutable-market-data";
 import { IBApiNextLogger } from "../core/api-next/logger";
+import { IBApiAutoConnection } from "../core/api-next/auto-connection";
 
 /**
  * @internal

--- a/src/api-next/common/error.ts
+++ b/src/api-next/common/error.ts
@@ -1,4 +1,4 @@
-import { ErrorCode } from "..";
+import { ErrorCode } from "../..";
 
 /**
  * An error on the TWS / IB Gateway API or IBApiNext.

--- a/src/api-next/index.ts
+++ b/src/api-next/index.ts
@@ -1,27 +1,4 @@
-export {
-  IBApi,
-  IBApiCreationOptions,
-  EventName,
-  ErrorCode,
-  LogLevel,
-  Contract,
-} from "..";
-
-export { IBApiNext, IBApiNextCreationOptions } from "./api-next";
-
-export { IBApiNextError } from "./common/error";
-export { Logger } from "./common/logger";
-export { ItemListUpdate as DataUpdate } from "./common/item-list-update";
-export { ConnectionState } from "./common/connection-state";
-export { IBApiAutoConnection as IBApiAutoConnection } from "../core/api-next/auto-connection";
-
-import { TickType as IBApiTickType } from "../api/market/tickType";
-export { IBApiTickType };
-
-import { TickType as IBApiNextTickType } from "./market/tick-type";
-export { IBApiNextTickType };
-
-export type TickType = IBApiTickType | IBApiNextTickType;
+// account
 
 export {
   AccountSummaries,
@@ -32,14 +9,37 @@ export {
   AccountSummariesUpdate,
 } from "./account/account-summary";
 
-export { ContractDetailsUpdate } from "./contract/contract-details-update";
-
-export { ItemListUpdate } from "./common/item-list-update";
+// common
 
 export { AccountId, ConId, CurrencyCode } from "./common/common-types";
+export { IBApiNextError } from "./common/error";
+export { Logger } from "./common/logger";
+export { ItemListUpdate } from "./common/item-list-update";
+export { ConnectionState } from "./common/connection-state";
+
+// contract
+
+export { ContractDetailsUpdate } from "./contract/contract-details-update";
+
+// market
+
+export { MarketDataType } from "./market/market-data-type";
+export {
+  MarketDataTick,
+  MarketDataTicks,
+  MarketDataUpdate,
+} from "./market/market-data";
+import { TickType as IBApiTickType } from "../api/market/tickType";
+export { IBApiTickType };
+import { TickType as IBApiNextTickType } from "./market/tick-type";
+export { IBApiNextTickType };
+
+// pnl
 
 export { PnL } from "./pnl/pnl";
 export { PnLSingle } from "./pnl/pnl-single";
+
+// position
 
 export {
   Position,
@@ -47,9 +47,6 @@ export {
   AccountPositionsUpdate,
 } from "./position/position";
 
-export {
-  MarketDataTick,
-  MarketDataTicks,
-  MarketDataUpdate,
-} from "./market/market-data";
-export { MarketDataType } from "./market/market-data-type";
+// IBApiNext
+
+export { IBApiNext, IBApiNextCreationOptions } from "./api-next";

--- a/src/api-next/market/market-data.ts
+++ b/src/api-next/market/market-data.ts
@@ -1,4 +1,4 @@
-import { ItemListUpdate, TickType } from "..";
+import { TickType, ItemListUpdate } from "../..";
 
 /**  A market data tick on [[IBApiNext]]. */
 export interface MarketDataTick {

--- a/src/api-next/position/position.ts
+++ b/src/api-next/position/position.ts
@@ -1,4 +1,4 @@
-import { Contract, AccountId, ItemListUpdate } from "..";
+import { AccountId, Contract, ItemListUpdate } from "../..";
 
 /**
  * A position on an IBKR account.

--- a/src/core/api-next/api/market/mutable-market-data.ts
+++ b/src/core/api-next/api/market/mutable-market-data.ts
@@ -1,5 +1,5 @@
+import { TickType } from "../../../..";
 import {
-  TickType,
   MarketDataTick,
   MarketDataTicks,
   MarketDataUpdate,

--- a/src/core/api-next/auto-connection.ts
+++ b/src/core/api-next/auto-connection.ts
@@ -1,11 +1,10 @@
 import { BehaviorSubject, Observable } from "rxjs";
-import {
+import IBApi, {
   ConnectionState,
   ErrorCode,
   EventName,
-  IBApi,
   IBApiCreationOptions,
-} from "../../api-next";
+} from "../..";
 import { Logger } from "../../api-next/common/logger";
 
 /** The log tag. */
@@ -38,6 +37,7 @@ export class IBApiAutoConnection extends IBApi {
     super(options);
     this.on(EventName.connected, () => this.onConnected());
     this.on(EventName.disconnected, () => this.onDisconnected());
+    this.on(EventName.received, () => (this.lastDataIngressTm = Date.now()));
     this.on(EventName.error, (error, code, reqId) => {
       this.logger.error(
         "TWS",
@@ -47,10 +47,7 @@ export class IBApiAutoConnection extends IBApi {
         this.onDisconnected();
       }
     });
-    this.on(
-      EventName.currentTime,
-      () => (this.lastCurrentTimeIngress = Date.now())
-    );
+    this.on(EventName.currentTime, () => (this.lastDataIngressTm = Date.now()));
   }
 
   /**
@@ -83,8 +80,8 @@ export class IBApiAutoConnection extends IBApi {
   /** The connection-watchdog timeout. */
   private connectionWatchdogTimeout?: ReturnType<typeof setTimeout>;
 
-  /** Ingress timestamp of last received [[EventName.currentTime]] event. */
-  private lastCurrentTimeIngress?: number;
+  /** Ingress timestamp of last received message data from TWS. */
+  private lastDataIngressTm?: number;
 
   /** The connection-state [[BehaviorSubject]]. */
   private readonly _connectionState = new BehaviorSubject<ConnectionState>(
@@ -110,7 +107,8 @@ export class IBApiAutoConnection extends IBApi {
     this.autoReconnectEnabled = true;
     this.fixedClientId = clientId;
     this.currentClientId =
-      (clientId === undefined ? this.options?.clientId : clientId) ?? 0;
+      (clientId === undefined ? this.options?.clientId : clientId) ??
+      Math.floor(Math.random() * 100) + 1;
     if (this._connectionState.getValue() === ConnectionState.Disconnected) {
       this._connectionState.next(ConnectionState.Connecting);
       this.logger.info(
@@ -187,6 +185,8 @@ export class IBApiAutoConnection extends IBApi {
       LOG_TAG,
       `Re-Connecting to TWS with client id ${this.currentClientId}`
     );
+
+    super.disconnect();
     super.connect(this.currentClientId);
   }
 
@@ -244,24 +244,23 @@ export class IBApiAutoConnection extends IBApi {
       `Starting connection watchdog with ${this.CONNECTION_WATCHDOG_INTERVAL}ms interval.`
     );
 
-    let lastReqCurrentTimeEgress = 0;
     this.connectionWatchdogTimeout = setInterval(() => {
-      if (this.lastCurrentTimeIngress !== undefined) {
-        const elapsed = this.lastCurrentTimeIngress - lastReqCurrentTimeEgress;
-        if (
-          lastReqCurrentTimeEgress &&
-          elapsed > this.CONNECTION_WATCHDOG_INTERVAL * 2
-        ) {
-          this.logger.debug(
-            LOG_TAG,
-            "Connection watchdog timeout. Dropping connection."
-          );
-          this.onDisconnected();
-          return;
+      let triggerReconnect = false;
+      if (this.lastDataIngressTm === undefined) {
+        triggerReconnect = true;
+      } else {
+        const elapsed = Date.now() - this.lastDataIngressTm;
+        if (elapsed > this.CONNECTION_WATCHDOG_INTERVAL) {
+          triggerReconnect = true;
         }
       }
-      lastReqCurrentTimeEgress = Date.now();
-      this.reqCurrentTime();
+      if (triggerReconnect) {
+        this.logger.debug(
+          LOG_TAG,
+          "Connection watchdog timeout. Dropping connection."
+        );
+        this.onDisconnected();
+      }
     }, this.CONNECTION_WATCHDOG_INTERVAL);
   }
 
@@ -294,6 +293,7 @@ export class IBApiAutoConnection extends IBApi {
         `Disconnecting client id ${this.currentClientId} from TWS (state-sync).`
       );
       this.disconnect();
+      this.autoReconnectEnabled = true;
     }
 
     if (this._connectionState.getValue() !== ConnectionState.Disconnected) {

--- a/src/core/api-next/auto-connection.ts
+++ b/src/core/api-next/auto-connection.ts
@@ -261,6 +261,8 @@ export class IBApiAutoConnection extends IBApi {
         );
         this.onDisconnected();
       }
+      // trigger at least some message if connection is idle
+      this.reqCurrentTime();
     }, this.CONNECTION_WATCHDOG_INTERVAL);
   }
 

--- a/src/core/api-next/console-logger.ts
+++ b/src/core/api-next/console-logger.ts
@@ -1,7 +1,6 @@
 import colors from "colors";
 import * as util from "util";
-import { Logger, LogLevel } from "../../api-next";
-
+import { Logger, LogLevel } from "../..";
 
 /**
  * @internal

--- a/src/core/api-next/subscription-registry.ts
+++ b/src/core/api-next/subscription-registry.ts
@@ -1,5 +1,7 @@
 import { Observable } from "rxjs";
-import { EventName, IBApiAutoConnection, IBApiNextError, IBApiNext, DataUpdate } from "../../api-next";
+import { EventName } from "../..";
+import { IBApiNextError, IBApiNext, ItemListUpdate } from "../../api-next";
+import { IBApiAutoConnection } from "./auto-connection";
 import { IBApiNextMap } from "./map";
 import { IBApiNextSubscription } from "./subscription";
 
@@ -94,7 +96,7 @@ export class IBApiNextSubscriptionRegistry {
       ) => void
     ][],
     instanceId?: string
-  ): Observable<DataUpdate<T>> {
+  ): Observable<ItemListUpdate<T>> {
     // get the existing registry entries, or add if not existing yet
 
     const entires: RegistryEntry[] = [];

--- a/src/core/api-next/subscription.ts
+++ b/src/core/api-next/subscription.ts
@@ -1,8 +1,7 @@
-import { IBApiNextError, IBApiNext } from "../../api-next";
+import { IBApiNextError, IBApiNext, ItemListUpdate } from "../../api-next";
 import { Observable, ReplaySubject, Subscription } from "rxjs";
 import { ConnectionState } from "../../api-next/common/connection-state";
 import { IBApiNextItemListUpdate } from "./item-list-update";
-import { DataUpdate } from "../../api-next";
 import { map } from "rxjs/operators";
 
 /**
@@ -88,8 +87,8 @@ export class IBApiNextSubscription<T> {
    * Create an Observable to start/stop the subscription on
    * TWS, receive update and error events.
    */
-  createObservable(): Observable<DataUpdate<T>> {
-    return new Observable<DataUpdate<T>>((subscriber) => {
+  createObservable(): Observable<ItemListUpdate<T>> {
+    return new Observable<ItemListUpdate<T>>((subscriber) => {
       // create new subject and reqId if there is an has error
 
       if (this.subject.hasError) {
@@ -106,7 +105,7 @@ export class IBApiNextSubscription<T> {
               ? ({
                   all: val.all,
                   added: val.all,
-                } as DataUpdate<T>)
+                } as ItemListUpdate<T>)
               : val;
           })
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,33 +126,8 @@ export default IBApi;
 
 // export IBApiNext types
 
-export {
-  IBApiNext,
-  IBApiNextError,
-  IBApiAutoConnection,
-  AccountId,
-  ConId,
-  CurrencyCode,
-  ItemListUpdate,
-  AccountSummaries,
-  AccountSummaryTagName,
-  AccountSummaryTagValues,
-  AccountSummaryValue,
-  AccountSummaryValues,
-  AccountSummariesUpdate,
-  ContractDetailsUpdate,
-  PnL,
-  PnLSingle,
-  Position,
-  AccountPositions,
-  AccountPositionsUpdate,
-  MarketDataTick,
-  MarketDataTicks,
-  MarketDataUpdate,
-  MarketDataType,
-} from "./api-next";
+export * from "./api-next";
 
-import { TickType as IBApiNextTickType } from "./api-next/market/tick-type";
-
+import { IBApiNextTickType } from "./api-next";
 /** Combination of IBApi and IBApiNext market data tick types. */
 export type TickType = IBApiTickType | IBApiNextTickType;

--- a/src/tests/unit/api-next/get-account-summary.test.ts
+++ b/src/tests/unit/api-next/get-account-summary.test.ts
@@ -3,18 +3,12 @@
  */
 
 import { take } from "rxjs/operators";
-import {
-  IBApiNext,
-  IBApiAutoConnection,
-  IBApiNextError,
-  EventName,
-} from "../../..";
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
 
 describe("RxJS Wrapper: getAccountSummary()", () => {
   test("Error Event", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a error event and verify RxJS result
 
@@ -38,8 +32,7 @@ describe("RxJS Wrapper: getAccountSummary()", () => {
 
   test("Update multicast", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 
@@ -154,8 +147,7 @@ describe("RxJS Wrapper: getAccountSummary()", () => {
 
   test("Aggregate into all", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 
@@ -286,8 +278,7 @@ describe("RxJS Wrapper: getAccountSummary()", () => {
 
   test("Detected changes", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 
@@ -345,8 +336,7 @@ describe("RxJS Wrapper: getAccountSummary()", () => {
     // create IBApiNext and reqId counter
 
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 

--- a/src/tests/unit/api-next/get-contract-details.test.ts
+++ b/src/tests/unit/api-next/get-contract-details.test.ts
@@ -3,8 +3,8 @@
  */
 
 import {
+  IBApi,
   IBApiNext,
-  IBApiAutoConnection,
   IBApiNextError,
   EventName,
   ContractDetails,
@@ -13,8 +13,7 @@ import {
 describe("RxJS Wrapper: getContractDetails()", () => {
   test("Error Event", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a error event and verify RxJS result
 
@@ -38,8 +37,7 @@ describe("RxJS Wrapper: getContractDetails()", () => {
 
   test("Incremental collection", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit contractDetails and contractDetailsEnd event and verify all subscribers receive it
 

--- a/src/tests/unit/api-next/get-current-time.test.ts
+++ b/src/tests/unit/api-next/get-current-time.test.ts
@@ -2,20 +2,14 @@
  * This file implements tests for the [[IBApiNext.getCurrentTime]] function.
  */
 
-import {
-  IBApiNext,
-  IBApiAutoConnection,
-  IBApiNextError,
-  EventName,
-} from "../../..";
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
 
 describe("RxJS Wrapper: getCurrentTime()", () => {
   test("Promise result", (done) => {
     // create IBApiNext
 
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a EventName.currentTime and verify RxJS result
 

--- a/src/tests/unit/api-next/get-managed-accounts.test.ts
+++ b/src/tests/unit/api-next/get-managed-accounts.test.ts
@@ -2,20 +2,14 @@
  * This file implements tests for the [[IBApiNext.getManagedAccounts]] function.
  */
 
-import {
-  IBApiNext,
-  IBApiAutoConnection,
-  IBApiNextError,
-  EventName,
-} from "../../..";
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
 
 describe("RxJS Wrapper: getManagedAccounts()", () => {
   test("Promise result", (done) => {
     // create IBApiNext
 
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a EventName.managedAccounts and verify RxJS result
 

--- a/src/tests/unit/api-next/get-market-data.test.ts
+++ b/src/tests/unit/api-next/get-market-data.test.ts
@@ -3,20 +3,14 @@
  */
 
 import { take } from "rxjs/operators";
-import {
-  IBApiNext,
-  IBApiAutoConnection,
-  IBApiNextError,
-  EventName,
-} from "../../..";
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
 import { IBApiNextTickType, IBApiTickType } from "../../../api-next";
 import TickType from "../../../api/market/tickType";
 
 describe("RxJS Wrapper: getPnL()", () => {
   test("Error Event", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a error event and verify RxJS result
 
@@ -40,8 +34,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("tickPrice events", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a tickPrice events and verify RxJS result
 
@@ -76,8 +69,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("tickSize events", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a tickSize events and verify RxJS result
 
@@ -116,8 +108,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("tickGeneric events", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a tickGeneric events and verify RxJS result
 
@@ -157,8 +148,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("tickOptionComputationHandler events", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a tickOptionComputationHandler events and verify RxJS result
 
@@ -238,8 +228,7 @@ describe("RxJS Wrapper: getPnL()", () => {
     // create IBApiNext and reqId counter
 
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a tickPrice events and verify RxJS result
 

--- a/src/tests/unit/api-next/get-pnl-signle.test.ts
+++ b/src/tests/unit/api-next/get-pnl-signle.test.ts
@@ -2,18 +2,12 @@
  * This file implements tests for the [[IBApiNext.getPnLSingle]] function.
  */
 
-import {
-  IBApiNext,
-  IBApiAutoConnection,
-  IBApiNextError,
-  EventName,
-} from "../../..";
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
 
 describe("RxJS Wrapper: getPnL()", () => {
   test("Error Event", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a error event and verify RxJS result
 
@@ -37,8 +31,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("Value update", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a pnl event and verify RxJS result
 
@@ -78,8 +71,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("Initial value replay to late observers", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a pnl event and verify RxJS result
 
@@ -130,8 +122,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("Multiple contracts with multiple subscribers", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 

--- a/src/tests/unit/api-next/get-pnl.test.ts
+++ b/src/tests/unit/api-next/get-pnl.test.ts
@@ -2,18 +2,12 @@
  * This file implements tests for the [[IBApiNext.getPnL]] function.
  */
 
-import {
-  IBApiNext,
-  IBApiAutoConnection,
-  IBApiNextError,
-  EventName,
-} from "../../..";
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
 
 describe("RxJS Wrapper: getPnL()", () => {
   test("Error Event", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a error event and verify RxJS result
 
@@ -37,8 +31,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("Value update", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a pnl event and verify RxJS result
 
@@ -66,8 +59,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("Initial value replay to late observers", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // emit a pnl event and verify RxJS result
 
@@ -105,8 +97,7 @@ describe("RxJS Wrapper: getPnL()", () => {
 
   test("Multi-account with multiple-subscribers", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 

--- a/src/tests/unit/api-next/get-positions.test.ts
+++ b/src/tests/unit/api-next/get-positions.test.ts
@@ -3,8 +3,8 @@
  */
 
 import {
+  IBApi,
   IBApiNext,
-  IBApiAutoConnection,
   IBApiNextError,
   EventName,
   Contract,
@@ -13,8 +13,7 @@ import {
 describe("RxJS Wrapper: getPositions()", () => {
   test("Update multicast", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 
@@ -62,8 +61,7 @@ describe("RxJS Wrapper: getPositions()", () => {
 
   test("Detected added / changed / removed", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 
@@ -121,8 +119,7 @@ describe("RxJS Wrapper: getPositions()", () => {
 
   test("Initial value replay to late observers", (done) => {
     const apiNext = new IBApiNext();
-    const api = ((apiNext as unknown) as Record<string, unknown>)
-      .api as IBApiAutoConnection;
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
 
     // testing values
 

--- a/src/tools/account-summary.ts
+++ b/src/tools/account-summary.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { Subscription } from "rxjs";
 
 import { IBApiNextError } from "../api-next";
+import LogLevel from "../api/data/enum/log-level";
 import logger from "../common/logger";
 import { IBApiNextApp } from "./common/ib-api-next-app";
 
@@ -66,6 +67,7 @@ class PrintAccountSummaryApp extends IBApiNextApp {
   start(): void {
     const scriptName = path.basename(__filename);
     logger.debug(`Starting ${scriptName} script`);
+
     this.connect(this.cmdLineArgs.watch ? 10000 : 0);
     this.subscription$ = this.api
       .getAccountSummary(


### PR DESCRIPTION
This PR has various changes related to IBApiNext, most are cosmetics.

In Detail:
- Export all IBApiNext types on the root-level index.ts
Some of the IBApiNext type where missing on root index.ts so you had to do stuff like 
```
import {something} from "@stoqey/ib/dist/somthing"
```
All IBApiNext type now exported via the root index.ts, so all you need
import * as IB from "@stoqey/ib"

- Make connection watchdog more robust again heavy message bursts.
The connection watchdog did rely on a sending a TWS time request and receiving an answer until the watchdog timeout.
During heavy message burst, it can happen that the request is stuck on the rater limiter, response does not arrive in time and watchdog triggers the re-connect. If have changed it so that now we measure the ingress timestamp of any kind of message (doesn't matter what it is) and only if no data arrive during a watchdog cycle, we re-connect. The  TWS time request on every cycle is still there is make sure there is data on otherwise idle connections.

- Use a random 1-100 client id of not configured.
We do not start with client_id=1 anymore, but we a use a random between 1-100, unless configured by the user.

- Updated doc.