### PR TITLE
Add dependency to colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "colors": "^1.4.0",
     "command-buffer": "^0.1.0",
     "dotenv": "^8.2.0",
     "eventemitter3": "^4.0.7",


### PR DESCRIPTION
v1.1.38 give the following error on my app:
```
Error: Cannot find module 'colors'
Require stack:
- c:\srcmfr\waytrade\ib-api-service\node_modules\@stoqey\ib\dist\core\api-next\console-logger.js
- c:\srcmfr\waytrade\ib-api-service\node_modules\@stoqey\ib\dist\api-next\api-next.js
- c:\srcmfr\waytrade\ib-api-service\node_modules\@stoqey\ib\dist\api-next\index.js
- c:\srcmfr\waytrade\ib-api-service\node_modules\@stoqey\ib\dist\index.js
- c:\srcmfr\waytrade\ib-api-service\dist\controllers\ib-api.controller.js
- c:\srcmfr\waytrade\ib-api-service\dist\controllers\index.js
- c:\srcmfr\waytrade\ib-api-service\dist\app.js
- c:\srcmfr\waytrade\ib-api-service\dist\index.js
- c:\srcmfr\waytrade\ib-api-service\dist\run.js
```
It is because of cleanup of the module dependencies. We need colors module, but it is not listed as a dependency. Apps on this repo continued to work because colors module as required by dev dependencies, so it was there, but an App that doesn't have it already will fail.
Therefore, added to dependency to colors module.