### PR TITLE
IBApiNext: Add support for getting historic data 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -186,5 +186,50 @@
         "!**/node_modules/**"
       ]
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tool: historical-data",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "--trace-warnings"
+      ],
+      "program": "${workspaceFolder}/dist/tools/historical-data.js",
+      "args": [
+        "-conid=3691937",
+        "-exchange=SMART",
+        "-duration=3 M",
+        "-barSize=1 day"
+      ],
+      "outputCapture": "std",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tool: historical-data-updates",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "--trace-warnings"
+      ],
+      "program": "${workspaceFolder}/dist/tools/historical-data-updates.js",
+      "args": [
+        "-conid=3691937",
+        "-exchange=SMART",
+        "-barSize=15 mins"
+      ],
+      "outputCapture": "std",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
   ]
 }

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1237,7 +1237,8 @@ export class IBApiNext {
 
     // update bar
 
-    const current = subscription.lastAllValue ?? { time };
+    const current = subscription.lastAllValue ?? {};
+    current.time = time;
     current.open = open !== -1 ? open : undefined;
     current.high = high !== -1 ? high : undefined;
     current.low = low !== -1 ? low : undefined;

--- a/src/core/api-next/auto-connection.ts
+++ b/src/core/api-next/auto-connection.ts
@@ -59,7 +59,7 @@ export class IBApiAutoConnection extends IBApi {
    * the connection will be considered as "dead" and a new connection
    * will be initialized after the [[reconnectInterval]].
    */
-  readonly CONNECTION_WATCHDOG_INTERVAL = 4000;
+  readonly CONNECTION_WATCHDOG_INTERVAL = 10000;
 
   /**
    * If defined, this is the client id that will be used on all
@@ -263,7 +263,7 @@ export class IBApiAutoConnection extends IBApi {
       }
       // trigger at least some message if connection is idle
       this.reqCurrentTime();
-    }, this.CONNECTION_WATCHDOG_INTERVAL);
+    }, this.CONNECTION_WATCHDOG_INTERVAL / 2);
   }
 
   /**

--- a/src/tests/unit/api-next/get-historical-data-updates.test.ts
+++ b/src/tests/unit/api-next/get-historical-data-updates.test.ts
@@ -1,0 +1,90 @@
+/**
+ * This file implements tests for the [[IBApiNext.getHistoricalDataUpdates]] function.
+ */
+
+import { IBApi, IBApiNext, IBApiNextError, EventName, Bar } from "../../..";
+
+describe("RxJS Wrapper: getHistoricalDataUpdates()", () => {
+  test("Observable updates", (done) => {
+    // create IBApiNext
+
+    const apiNext = new IBApiNext();
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
+
+    // emit EventName.historicalData events and verify RxJS result
+
+    const REF_BARS: Bar[] = [
+      {
+        time: "20210203 01:02:03",
+        open: 1,
+        high: 2,
+        low: 3,
+        close: 4,
+        volume: 5,
+        count: 6,
+        WAP: 7,
+      },
+      {
+        time: "20210203 02:02:03",
+        open: 11,
+        high: 12,
+        low: 13,
+        close: 14,
+        volume: 15,
+        count: 16,
+        WAP: 17,
+      },
+      {
+        time: "20210203 03:02:03",
+        open: 21,
+        high: 22,
+        low: 23,
+        close: 24,
+        volume: 25,
+        count: 26,
+        WAP: 27,
+      },
+    ];
+
+    let updateCount = 0;
+
+    apiNext
+      .getHistoricalDataUpdates({}, "", "", 0)
+      // eslint-disable-next-line rxjs/no-ignored-subscription
+      .subscribe({
+        next: (update) => {
+          expect(update.time).toEqual(REF_BARS[updateCount].time);
+          expect(update.open).toEqual(REF_BARS[updateCount].open);
+          expect(update.high).toEqual(REF_BARS[updateCount].high);
+          expect(update.low).toEqual(REF_BARS[updateCount].low);
+          expect(update.close).toEqual(REF_BARS[updateCount].close);
+          expect(update.volume).toEqual(REF_BARS[updateCount].volume);
+          expect(update.count).toEqual(REF_BARS[updateCount].count);
+          expect(update.WAP).toEqual(REF_BARS[updateCount].WAP);
+
+          updateCount++;
+          if (updateCount >= REF_BARS.length) {
+            done();
+          }
+        },
+        error: (err: IBApiNextError) => {
+          fail(err.error.message);
+        },
+      });
+
+    for (let i = 0; i < REF_BARS.length; i++) {
+      api.emit(
+        EventName.historicalDataUpdate,
+        1,
+        REF_BARS[i].time,
+        REF_BARS[i].open,
+        REF_BARS[i].high,
+        REF_BARS[i].low,
+        REF_BARS[i].close,
+        REF_BARS[i].volume,
+        REF_BARS[i].count,
+        REF_BARS[i].WAP
+      );
+    }
+  });
+});

--- a/src/tests/unit/api-next/get-historical-data.test.ts
+++ b/src/tests/unit/api-next/get-historical-data.test.ts
@@ -1,0 +1,116 @@
+/**
+ * This file implements tests for the [[IBApiNext.getHistoricalData]] function.
+ */
+
+import { IBApi, IBApiNext, IBApiNextError, EventName, Bar } from "../../..";
+
+describe("RxJS Wrapper: getHistoricalData()", () => {
+  test("Promise result", (done) => {
+    // create IBApiNext
+
+    const apiNext = new IBApiNext();
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
+
+    // emit EventName.historicalData and verify RxJS result
+
+    const REF_BARS: Bar[] = [
+      {
+        time: "20210203 01:02:03",
+        open: 1,
+        high: 2,
+        low: 3,
+        close: 4,
+        volume: 5,
+        count: 6,
+        WAP: 7,
+      },
+      {
+        time: "20210203 02:02:03",
+        open: 11,
+        high: 12,
+        low: 13,
+        close: 14,
+        volume: 15,
+        count: 16,
+        WAP: 17,
+      },
+      {
+        time: "20210203 03:02:03",
+        open: 21,
+        high: 22,
+        low: 23,
+        close: 24,
+        volume: 25,
+        count: 26,
+        WAP: 27,
+      },
+    ];
+
+    apiNext
+      .getHistoricalData({}, "", "", "", "", 0, 1)
+      .then((bars) => {
+        for (let i = 0; i < REF_BARS.length; i++) {
+          expect(bars[i].time).toEqual(REF_BARS[i].time);
+          expect(bars[i].open).toEqual(REF_BARS[i].open);
+          expect(bars[i].high).toEqual(REF_BARS[i].high);
+          expect(bars[i].low).toEqual(REF_BARS[i].low);
+          expect(bars[i].close).toEqual(REF_BARS[i].close);
+          expect(bars[i].volume).toEqual(REF_BARS[i].volume);
+          expect(bars[i].count).toEqual(REF_BARS[i].count);
+          expect(bars[i].WAP).toEqual(REF_BARS[i].WAP);
+        }
+        done();
+      })
+      .catch((err: IBApiNextError) => {
+        fail(err.error.message);
+      });
+
+    REF_BARS.forEach((bar) => {
+      api.emit(
+        EventName.historicalData,
+        1,
+        bar.time,
+        bar.open,
+        bar.high,
+        bar.low,
+        bar.close,
+        bar.volume,
+        bar.count,
+        bar.WAP
+      );
+    });
+
+    api.emit(
+      EventName.historicalData,
+      1,
+      "finished-",
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    );
+  });
+
+  test("Promise error", (done) => {
+    // create IBApiNext
+
+    const apiNext = new IBApiNext();
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
+
+    // emit EventName.error and verify RxJS result
+
+    apiNext
+      .getHistoricalData({}, "", "", "", "", 0, 1)
+      .then(() => {
+        fail();
+      })
+      .catch(() => {
+        done();
+      });
+
+    api.emit(EventName.error, {}, -1, 1);
+  });
+});

--- a/src/tests/unit/api-next/get-historical-data.test.ts
+++ b/src/tests/unit/api-next/get-historical-data.test.ts
@@ -65,20 +65,20 @@ describe("RxJS Wrapper: getHistoricalData()", () => {
         fail(err.error.message);
       });
 
-    REF_BARS.forEach((bar) => {
+    for (let i = 0; i < REF_BARS.length; i++) {
       api.emit(
         EventName.historicalData,
         1,
-        bar.time,
-        bar.open,
-        bar.high,
-        bar.low,
-        bar.close,
-        bar.volume,
-        bar.count,
-        bar.WAP
+        REF_BARS[i].time,
+        REF_BARS[i].open,
+        REF_BARS[i].high,
+        REF_BARS[i].low,
+        REF_BARS[i].close,
+        REF_BARS[i].volume,
+        REF_BARS[i].count,
+        REF_BARS[i].WAP
       );
-    });
+    }
 
     api.emit(
       EventName.historicalData,

--- a/src/tools/common/ib-api-next-app.ts
+++ b/src/tools/common/ib-api-next-app.ts
@@ -59,7 +59,7 @@ export class IBApiNextApp {
   protected cmdLineArgs: Record<string, string>;
 
   /** Connect to TWS. */
-  connect(reconnectInterval: number): void {
+  connect(reconnectInterval?: number): void {
     // create the IBApiNext object
 
     if (!this.api) {

--- a/src/tools/historical-data-updates.ts
+++ b/src/tools/historical-data-updates.ts
@@ -1,0 +1,92 @@
+/**
+ * This App will print real-time updates of the latest historical data bar of a contract.
+ */
+import path from "path";
+import { Subscription } from "rxjs";
+
+import { IBApiNextError } from "../api-next";
+import logger from "../common/logger";
+import { IBApiNextApp } from "./common/ib-api-next-app";
+
+/////////////////////////////////////////////////////////////////////////////////
+// The help text                                                               //
+/////////////////////////////////////////////////////////////////////////////////
+
+const DESCRIPTION_TEXT = "Print historical chart data of a contract.";
+const USAGE_TEXT = "Usage: historical-data.js <options>";
+const OPTION_ARGUMENTS: [string, string][] = [
+  [
+    "conid=<number>",
+    "(required) Contract ID (conId) of contract to receive daily PnL updates for.",
+  ],
+  ["exchange=<name>", "The destination exchange name."],
+  ["barSize=<durationString>", "(required) The data granularity."],
+];
+const EXAMPLE_TEXT =
+  "historical-data-updates.js -conid=3691937 -exchange=SMART -barSize=15 mins";
+
+//////////////////////////////////////////////////////////////////////////////
+// The App code                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+class PrintPositionsApp extends IBApiNextApp {
+  constructor() {
+    super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
+  }
+
+  /** The [[Subscription]] on the account summary. */
+  private subscription$: Subscription;
+
+  /**
+   * Start the the app.
+   */
+  start(): void {
+    const scriptName = path.basename(__filename);
+    logger.debug(`Starting ${scriptName} script`);
+
+    if (!this.cmdLineArgs.conid) {
+      this.error("-conid argument missing.");
+    }
+    if (!this.cmdLineArgs.exchange) {
+      this.error("-exchange argument missing.");
+    }
+    if (!this.cmdLineArgs.barSize) {
+      this.error("-barSize argument missing.");
+    }
+
+    this.connect(10000);
+
+    this.subscription$ = this.api
+      .getHistoricalDataUpdates(
+        {
+          conId: Number(this.cmdLineArgs.conid),
+          exchange: this.cmdLineArgs.exchange,
+        },
+        this.cmdLineArgs.barSize,
+        "MIDPOINT",
+        1
+      )
+      .subscribe({
+        next: (bar) => {
+          this.printObject(bar);
+        },
+        error: (err: IBApiNextError) => {
+          this.error(
+            `getHistoricalDataUpdates failed with '${err.error.message}'`
+          );
+        },
+      });
+  }
+
+  /**
+   * Stop the the app with success code.
+   */
+  stop() {
+    this.subscription$?.unsubscribe();
+    this.exit();
+  }
+}
+
+// run the app
+
+new PrintPositionsApp().start();

--- a/src/tools/historical-data.ts
+++ b/src/tools/historical-data.ts
@@ -1,0 +1,103 @@
+/**
+ * This App will print historical chart data of a contract.
+ */
+import path from "path";
+
+import { IBApiNextError } from "../api-next";
+import logger from "../common/logger";
+import { IBApiNextApp } from "./common/ib-api-next-app";
+
+/////////////////////////////////////////////////////////////////////////////////
+// The help text                                                               //
+/////////////////////////////////////////////////////////////////////////////////
+
+const DESCRIPTION_TEXT = "Print historical chart data of a contract.";
+const USAGE_TEXT = "Usage: historical-data-updates.js <options>";
+const OPTION_ARGUMENTS: [string, string][] = [
+  [
+    "conid=<number>",
+    "(required) Contract ID (conId) of contract to receive daily PnL updates for.",
+  ],
+  ["exchange=<name>", "The destination exchange name."],
+  [
+    "duration=<durationString>",
+    "(required) The amount of time to go back from the request's given end date and time.",
+  ],
+  ["barSize=<durationString>", "(required) The data granularity."],
+  [
+    "endTime=<dateTimeString>",
+    "(optional) Request's ending time with format yyyyMMdd HH:mm:ss {TMZ}. Today/now will be used if not specified.",
+  ],
+];
+const EXAMPLE_TEXT =
+  "historical-data.js -conid=3691937 -exchange=SMART -duration=3 M -barSize=1 day";
+
+//////////////////////////////////////////////////////////////////////////////
+// The App code                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+class PrintPositionsApp extends IBApiNextApp {
+  constructor() {
+    super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
+  }
+
+  /**
+   * Start the the app.
+   */
+  start(): void {
+    const scriptName = path.basename(__filename);
+    logger.debug(`Starting ${scriptName} script`);
+
+    if (!this.cmdLineArgs.conid) {
+      this.error("-conid argument missing.");
+    }
+    if (!this.cmdLineArgs.exchange) {
+      this.error("-exchange argument missing.");
+    }
+    if (!this.cmdLineArgs.duration) {
+      this.error("-duration argument missing.");
+    }
+    if (!this.cmdLineArgs.barSize) {
+      this.error("-barSize argument missing.");
+    }
+
+    let endTime = this.cmdLineArgs.endTime;
+    if (!endTime) {
+      const now = new Date();
+      endTime = `${now.getFullYear()}${("0" + (now.getMonth() + 1)).slice(
+        -2
+      )}${("0" + now.getDate()).slice(-2)} ${("0" + now.getHours()).slice(
+        -2
+      )}:${("0" + now.getMinutes()).slice(-2)}:${("0" + now.getSeconds()).slice(
+        -2
+      )}`;
+    }
+
+    this.connect();
+
+    this.api
+      .getHistoricalData(
+        {
+          conId: Number(this.cmdLineArgs.conid),
+          exchange: this.cmdLineArgs.exchange,
+        },
+        this.cmdLineArgs.endTime,
+        this.cmdLineArgs.duration,
+        this.cmdLineArgs.barSize,
+        "MIDPOINT",
+        0,
+        1
+      )
+      .then((bars) => {
+        this.printObject(bars);
+        this.exit();
+      })
+      .catch((err: IBApiNextError) => {
+        this.error(`getHistoricalData failed with '${err.error.message}'`);
+      });
+  }
+}
+
+// run the app
+
+new PrintPositionsApp().start();


### PR DESCRIPTION
This PR adds support for getting historic data to IBApiNext.
New functions:
- ` getHistoricalData: Promise<Bar[]>`
- `getHistoricalDataUpdates: Observable<Bar>`

Also I did a small tweak on connection watchdog: increased timeout value to 10s and doubled request frequency. 
This is to avoid connection drops during outside trading hours, when TWS behaves 'laggy', like e.g. on weekends as of right now for me (takes up 4-5s for TWS to response to a request - only happens very randomly during market closed hours and goes away after some time automatically - so increased our watchdog thresholds to survive such phases w/o constant re-connection attempts).