### PR TITLE
Add test (and sample) code for placeOrder with PriceCondition

### DIFF
--- a/src/tests/unit/api/order/placeOrder.test.ts
+++ b/src/tests/unit/api/order/placeOrder.test.ts
@@ -53,7 +53,7 @@ describe("RequestAllOpenOrders", () => {
         lmtPrice: 1,
         orderId,
         totalQuantity: 1,
-        account: "DU3387025",
+        account: "DU123567",
         conditionsIgnoreRth: true,
         conditionsCancelOrder: false,
         conditions: [priceCondition],

--- a/src/tests/unit/api/order/placeOrder.test.ts
+++ b/src/tests/unit/api/order/placeOrder.test.ts
@@ -19,7 +19,7 @@ describe("RequestAllOpenOrders", () => {
 
   test("placeOrder with PriceCondition", (done) => {
     const ib = new IBApi({
-      port: 7497, // use Gateway
+      port: 4002, // use Gateway
     });
 
     ib.on(EventName.error, (error: Error, code: ErrorCode, reqId: number) => {

--- a/src/tests/unit/api/order/placeOrder.test.ts
+++ b/src/tests/unit/api/order/placeOrder.test.ts
@@ -1,0 +1,84 @@
+/**
+ * This file implement test code for the placeOrder function .
+ */
+import {
+  ConjunctionConnection,
+  Contract,
+  ErrorCode,
+  EventName,
+  IBApi,
+  OrderAction,
+  OrderType,
+  PriceCondition,
+  SecType,
+  TriggerMethod,
+} from "../../../..";
+import OptionType from "../../../../api/data/enum/option-type";
+describe("RequestAllOpenOrders", () => {
+  jest.setTimeout(20000);
+
+  test("placeOrder with PriceCondition", (done) => {
+    const ib = new IBApi({
+      port: 7497, // use Gateway
+    });
+
+    ib.on(EventName.error, (error: Error, code: ErrorCode, reqId: number) => {
+      fail(error.message);
+    }).once(EventName.nextValidId, (orderId: number) => {
+      // buy an Apple call, with a PriceCondition on underlying
+
+      const contract: Contract = {
+        symbol: "AAPL",
+        exchange: "CBOE",
+        currency: "USD",
+        secType: SecType.OPT,
+        right: OptionType.Call,
+        strike: 130,
+        multiplier: 100,
+        lastTradeDateOrContractMonth: "20230616",
+      };
+
+      const priceCondition: PriceCondition = new PriceCondition(
+        29,
+        TriggerMethod.Default,
+        3691937, // APPLE Stock on SMART
+        "SMART",
+        true,
+        ConjunctionConnection.OR
+      );
+
+      ib.placeOrder(orderId, contract, {
+        orderType: OrderType.LMT,
+        action: OrderAction.BUY,
+        lmtPrice: 1,
+        orderId,
+        totalQuantity: 1,
+        account: "DU3387025",
+        conditionsIgnoreRth: true,
+        conditionsCancelOrder: false,
+        conditions: [priceCondition],
+      });
+
+      // verify result
+      let finished = false;
+
+      ib.on(EventName.openOrder, (orderId, contract, order, orderState) => {
+        if (orderId === orderId) {
+          // done
+          ib.disconnect();
+          finished = true;
+          done();
+        }
+      }).on(EventName.openOrderEnd, () => {
+        if (!finished) {
+          fail();
+        }
+      });
+
+      ib.reqAllOpenOrders();
+    });
+
+    ib.connect();
+    ib.reqIds();
+  });
+});


### PR DESCRIPTION
Added test (and sample) code for placeOrder with PriceCondition.
Initiated by https://github.com/stoqey/ib/issues/78 to test if PriceCondition works and have sample code.

btw.. need to ping my broker again, completely forgot about the paper-accounts.. at some point those tests should actually run on CI.