### PR TITLE
Fix rate limiter

### DIFF
--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -93,7 +93,6 @@ export interface IBApiNextCreationOptions {
    * activity and triggers a re-connect if TWS/IB Gateway does not response within
    * the given amount of time.
    * If 0 or undefined, the connection-watchdog will be disabled.
-   * Default is 60 (1min).
    */
   connectionWatchdogInterval?: number;
 

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -87,6 +87,27 @@ export interface IBApiNextCreationOptions {
   reconnectInterval?: number;
 
   /**
+   * The connection-watchdog timeout interval in seconds.
+   *
+   * The connection-watchdog monitors the socket connection to TWS/IB Gateway for
+   * activity and triggers a re-connect if TWS/IB Gateway does not response within
+   * the given amount of time.
+   * If 0 or undefined, the connection-watchdog will be disabled.
+   * Default is 60 (1min).
+   */
+  connectionWatchdogInterval?: number;
+
+  /**
+   * Max. number of requests per second, sent to TWS/IB Gateway.
+   * Default is 40. IB specifies 50 requests/s as maximum.
+   *
+   * Note that sending large amount of requests within a small amount of time, significantly increases resource
+   * consumption of the TWS/IB Gateway (especially memory consumption). If you experience any lags, hangs or crashes
+   * on TWS/IB Gateway while sending request bursts, try to reduce this value.
+   */
+  maxReqPerSec?: number;
+
+  /**
    * Custom logger implementation.
    *
    * By default [[IBApiNext]] does log to console.
@@ -131,6 +152,7 @@ export class IBApiNext {
 
     this.api = new IBApiAutoConnection(
       options?.reconnectInterval ?? 0,
+      (options?.connectionWatchdogInterval ?? 0) * 1000,
       this.logger,
       options
     );

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -56,6 +56,16 @@ export interface IBApiCreationOptions {
    * Use clientId argument [[IBApi.connect]] instead.
    */
   clientId?: number;
+
+  /**
+   * Max. number of requests per second, sent to TWS/IB Gateway.
+   * Default is 40. IB specifies 50 requests/s as maximum.
+   *
+   * Note that sending large amount of requests within a small amount of time, significantly increases resource
+   * consumption of the TWS/IB Gateway (especially memory consumption). If you experience any lags, hangs or crashes
+   * on TWS/IB Gateway while sending request bursts, try to reduce this value.
+   */
+  maxReqPerSec?: number;
 }
 
 /** Maximum supported version. */

--- a/src/core/io/controller.ts
+++ b/src/core/io/controller.ts
@@ -24,8 +24,8 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
   constructor(private ib: IBApi, private options?: IBApiCreationOptions) {
     this.socket = new Socket(this, this.options);
     this.commands.pause();
-    const rate = configuration.max_req_per_second ?? 40;
-    this.rateLimiter = rateLimit(rate / 10, 1000 / 10, (tokens) => {
+    const rate = options.maxReqPerSec ?? configuration.max_req_per_second ?? 40;
+    this.rateLimiter = rateLimit(rate / 10, 1000 / 10, (tokens: unknown[]) => {
       this.socket.send(tokens);
     });
   }
@@ -37,7 +37,7 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
   private readonly commands = new CommandBuffer(Controller.execute, this);
 
   /** The rate limiter function. */
-  private readonly rateLimiter: (arg: unknown) => void;
+  private readonly rateLimiter: (tokens: unknown[]) => void;
 
   /** The API message encoder. */
   readonly encoder = new Encoder(this);

--- a/src/core/io/controller.ts
+++ b/src/core/io/controller.ts
@@ -24,7 +24,8 @@ export class Controller implements EncoderCallbacks, DecoderCallbacks {
   constructor(private ib: IBApi, private options?: IBApiCreationOptions) {
     this.socket = new Socket(this, this.options);
     this.commands.pause();
-    const rate = options.maxReqPerSec ?? configuration.max_req_per_second ?? 40;
+    const rate =
+      options?.maxReqPerSec ?? configuration.max_req_per_second ?? 40;
     this.rateLimiter = rateLimit(rate / 10, 1000 / 10, (tokens: unknown[]) => {
       this.socket.send(tokens);
     });


### PR DESCRIPTION
I had random freezes of Gateway / TWS when sending out whole bunch of requests at once.
Was hunting this bug for quite some time now and finally found the reason for it: our rate-limiter doesn't limit anything (it's used wrong), causing TWS to tilt.
This PR does two changes:
- Fix the rate-limit function call, so that actually does limit rate.
- Instead of limiting n (default 40) request per 1000ms, we now limit n/10 per 100ms. So instead of sending 40 request in 1ms and than do nothing for 999ms, we now split it into 100ms blocks. Throughput is still same, but we shape traffic-bursts.
