### PR TITLE
IBApiNext: Handle warning codes properly

### DIFF
--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -163,6 +163,15 @@ export class IBApiNext {
       EventName.error,
       (error: Error, code: ErrorCode, reqId: number) => {
         const apiError: IBApiNextError = { error, code, reqId };
+        // handle warnings - they are also reported on TWS error callback, but we DO NOT want to emit
+        // it as error into the subject (and cancel the subscription).
+        if (code >= 2100 && code < 3000) {
+          this.logger.warn(
+            TWS_LOG_TAG,
+            `${error.message} - Code: ${code} - ReqId: ${reqId}`
+          );
+          return;
+        }
         // emit to the subscription subject
         if (reqId !== INVALID_REQ_ID) {
           this.subscriptions.dispatchError(reqId, apiError);

--- a/src/core/api-next/auto-connection.ts
+++ b/src/core/api-next/auto-connection.ts
@@ -41,11 +41,7 @@ export class IBApiAutoConnection extends IBApi {
     this.on(EventName.connected, () => this.onConnected());
     this.on(EventName.disconnected, () => this.onDisconnected());
     this.on(EventName.received, () => (this.lastDataIngressTm = Date.now()));
-    this.on(EventName.error, (error, code, reqId) => {
-      this.logger.error(
-        "TWS",
-        `${error.message} - Code: ${code} - ReqId: ${reqId}`
-      );
+    this.on(EventName.error, (error, code) => {
       if (code === ErrorCode.CONNECT_FAIL) {
         this.onDisconnected();
       }

--- a/src/core/api-next/logger.ts
+++ b/src/core/api-next/logger.ts
@@ -7,7 +7,7 @@ import { Logger } from "../../api-next/common/logger";
  * The logger proxy to filter log levels.
  */
 export class IBApiNextLogger {
-  constructor(private logger: Logger) { }
+  constructor(private logger: Logger) {}
 
   /** The current log level */
   private _logLevel = LogLevel.SYSTEM;
@@ -39,14 +39,14 @@ export class IBApiNextLogger {
   /** Log a warning. */
   warn(tag: string, args: unknown[] | string): void {
     if (this._logLevel >= LogLevel.WARN) {
-      this.logger.debug(tag, args);
+      this.logger.warn(tag, args);
     }
   }
 
   /** Log an error. */
   error(tag: string, args: unknown[] | string): void {
     if (this._logLevel >= LogLevel.ERROR) {
-      this.logger.debug(tag, args);
+      this.logger.error(tag, args);
     }
   }
 }


### PR DESCRIPTION
Just stumbled over a small, but very important detail on TWS doc:
https://interactivebrokers.github.io/tws-api/message_codes.html
`The TWS uses the IBApi.EWrapper.error method not only to deliver errors but also warnings or informative messages. This is done mostly for simplicity's sake `
.. but also warnings ...
Don't understand how this will simplify anything, but anyhow.. we must handle it. Right now all error callback dispatch into the rxjs subject as an error, so error callback is called and subscription is canceled. Not good if this is only warning, because subscription actually works, so no need to cancel.
We now handle error codes from 2100 to 2999 as warnings and log it, but we do not emit an error to rxjs.

PR also has a fix for the ApiNext logger (error and warn was converted to debug).


