### PR TITLE
IBApiNext: Add support for getting historical ticks and fix HISTORICAL_TICKS decoder

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -231,5 +231,74 @@
         "!**/node_modules/**"
       ]
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tool: historical-ticks-mid",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "--trace-warnings"
+      ],
+      "program": "${workspaceFolder}/dist/tools/historical-ticks-mid.js",
+      "args": [
+        "-conid=3691937",
+        "-exchange=SMART",
+        "-start=20210604 16:00:00",
+        "-count=100"
+      ],
+      "outputCapture": "std",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tool: historical-ticks-bid-ask",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "--trace-warnings"
+      ],
+      "program": "${workspaceFolder}/dist/tools/historical-ticks-bid-ask.js",
+      "args": [
+        "-conid=3691937",
+        "-exchange=SMART",
+        "-start=20210604 16:00:00",
+        "-count=100"
+      ],
+      "outputCapture": "std",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tool: historical-ticks-last",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "--trace-warnings"
+      ],
+      "program": "${workspaceFolder}/dist/tools/historical-ticks-last.js",
+      "args": [
+        "-conid=3691937",
+        "-exchange=SMART",
+        "-start=20210604 16:00:00",
+        "-count=100"
+      ],
+      "outputCapture": "std",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
   ]
 }

--- a/src/api/historical/historicalTickBidAsk.ts
+++ b/src/api/historical/historicalTickBidAsk.ts
@@ -27,7 +27,7 @@ export interface HistoricalTickBidAsk {
   /** The ask price of the historical tick. */
   priceAsk?: number;
 
-  /** he bid size of the historical tick. */
+  /** The bid size of the historical tick. */
   sizeBid?: number;
 
   /** The ask size of the historical tick. */

--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -2184,10 +2184,14 @@ export class Decoder {
     const tickCount = this.readInt();
     const ticks: HistoricalTick[] = new Array(tickCount);
     for (let i = 0; i < tickCount; i++) {
+      const time = this.readInt();
+      this.readInt();//for consistency
+      const price = this.readDouble();
+      const size = this.readInt();
       ticks[i] = {
-        time: this.readInt(),
-        price: this.readDouble(),
-        size: this.readInt(),
+        time,
+        price,
+        size,
       };
     }
     const done = this.readBool();

--- a/src/tests/unit/api-next/get-historical-ticks-bid-ask.test.ts
+++ b/src/tests/unit/api-next/get-historical-ticks-bid-ask.test.ts
@@ -1,0 +1,94 @@
+/**
+ * This file implements tests for the [[IBApiNext.getHistoricalTicksBidAsk]] function.
+ */
+
+import {
+  IBApi,
+  IBApiNext,
+  IBApiNextError,
+  EventName,
+  HistoricalTickBidAsk,
+} from "../../..";
+
+describe("RxJS Wrapper: getHistoricalTicksBidAsk()", () => {
+  test("Error Event", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit a error event and verify RxJS result
+
+    const testValue = "We want this error";
+
+    apiNext
+      .getHistoricalTicksBidAsk({}, "", "", 1, 1, false)
+      // eslint-disable-next-line rxjs/no-ignored-subscription
+      .subscribe({
+        next: () => {
+          fail();
+        },
+        error: (error: IBApiNextError) => {
+          expect(error.error.message).toEqual(testValue);
+          done();
+        },
+      });
+
+    api.emit(EventName.error, new Error(testValue), -1, 1);
+  });
+
+  test("Incremental collection and complete event", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit historicalTicks events and verify all subscribers receive it
+
+    const firstTick: HistoricalTickBidAsk = {
+      time: 12345,
+      priceBid: 101,
+      priceAsk: 102,
+      sizeBid: 104,
+      sizeAsk: 105,
+    };
+
+    const secondTick: HistoricalTickBidAsk = {
+      time: 12346,
+      priceBid: 201,
+      priceAsk: 202,
+      sizeBid: 204,
+      sizeAsk: 205,
+    };
+
+    apiNext
+      .getHistoricalTicksBidAsk({}, "", "", 1, 1, false)
+      // eslint-disable-next-line rxjs/no-ignored-subscription
+      .subscribe({
+        next: (ticks) => {
+          if (!ticks || !ticks.length || ticks.length > 2) {
+            fail();
+          }
+          if (ticks.length >= 1) {
+            expect(ticks[0].time).toEqual(firstTick.time);
+            expect(ticks[0].priceBid).toEqual(firstTick.priceBid);
+            expect(ticks[0].priceAsk).toEqual(firstTick.priceAsk);
+            expect(ticks[0].sizeBid).toEqual(firstTick.sizeBid);
+            expect(ticks[0].sizeAsk).toEqual(firstTick.sizeAsk);
+          }
+          if (ticks.length == 2) {
+            expect(ticks[1].time).toEqual(secondTick.time);
+            expect(ticks[1].priceBid).toEqual(secondTick.priceBid);
+            expect(ticks[1].priceAsk).toEqual(secondTick.priceAsk);
+            expect(ticks[1].sizeBid).toEqual(secondTick.sizeBid);
+            expect(ticks[1].sizeAsk).toEqual(secondTick.sizeAsk);
+          }
+        },
+        complete: () => {
+          done();
+        },
+        error: () => {
+          fail();
+        },
+      });
+
+    api.emit(EventName.historicalTicksBidAsk, 1, [firstTick], false);
+    api.emit(EventName.historicalTicksBidAsk, 1, [secondTick], true);
+  });
+});

--- a/src/tests/unit/api-next/get-historical-ticks-last.test.ts
+++ b/src/tests/unit/api-next/get-historical-ticks-last.test.ts
@@ -1,0 +1,90 @@
+/**
+ * This file implements tests for the [[IBApiNext.getHistoricalTicksLast]] function.
+ */
+
+import {
+  IBApi,
+  IBApiNext,
+  IBApiNextError,
+  EventName,
+  HistoricalTickLast,
+} from "../../..";
+
+describe("RxJS Wrapper: getHistoricalTicksLast()", () => {
+  test("Error Event", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit a error event and verify RxJS result
+
+    const testValue = "We want this error";
+
+    apiNext
+      .getHistoricalTicksLast({}, "", "", 1, 1)
+      // eslint-disable-next-line rxjs/no-ignored-subscription
+      .subscribe({
+        next: () => {
+          fail();
+        },
+        error: (error: IBApiNextError) => {
+          expect(error.error.message).toEqual(testValue);
+          done();
+        },
+      });
+
+    api.emit(EventName.error, new Error(testValue), -1, 1);
+  });
+
+  test("Incremental collection and complete event", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit historicalTicks events and verify all subscribers receive it
+
+    const firstTick: HistoricalTickLast = {
+      time: 12345,
+      price: 101,
+      size: 102,
+      exchange: "NYSE",
+    };
+
+    const secondTick: HistoricalTickLast = {
+      time: 12346,
+      price: 201,
+      size: 202,
+      exchange: "NASDAQ",
+    };
+
+    apiNext
+      .getHistoricalTicksLast({}, "", "", 1, 1)
+      // eslint-disable-next-line rxjs/no-ignored-subscription
+      .subscribe({
+        next: (ticks) => {
+          if (!ticks || !ticks.length || ticks.length > 2) {
+            fail();
+          }
+          if (ticks.length >= 1) {
+            expect(ticks[0].time).toEqual(firstTick.time);
+            expect(ticks[0].price).toEqual(firstTick.price);
+            expect(ticks[0].size).toEqual(firstTick.size);
+            expect(ticks[0].exchange).toEqual(firstTick.exchange);
+          }
+          if (ticks.length == 2) {
+            expect(ticks[1].time).toEqual(secondTick.time);
+            expect(ticks[1].price).toEqual(secondTick.price);
+            expect(ticks[1].size).toEqual(secondTick.size);
+            expect(ticks[1].exchange).toEqual(secondTick.exchange);
+          }
+        },
+        complete: () => {
+          done();
+        },
+        error: () => {
+          fail();
+        },
+      });
+
+    api.emit(EventName.historicalTicksLast, 1, [firstTick], false);
+    api.emit(EventName.historicalTicksLast, 1, [secondTick], true);
+  });
+});

--- a/src/tests/unit/api-next/get-historical-ticks-mid.test.ts
+++ b/src/tests/unit/api-next/get-historical-ticks-mid.test.ts
@@ -1,0 +1,86 @@
+/**
+ * This file implements tests for the [[IBApiNext.getHistoricalTicksMid]] function.
+ */
+
+import {
+  IBApi,
+  IBApiNext,
+  IBApiNextError,
+  EventName,
+  HistoricalTick,
+} from "../../..";
+
+describe("RxJS Wrapper: getHistoricalTicksMid()", () => {
+  test("Error Event", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit a error event and verify RxJS result
+
+    const testValue = "We want this error";
+
+    apiNext
+      .getHistoricalTicksMid({}, "", "", 1, 1)
+      // eslint-disable-next-line rxjs/no-ignored-subscription
+      .subscribe({
+        next: () => {
+          fail();
+        },
+        error: (error: IBApiNextError) => {
+          expect(error.error.message).toEqual(testValue);
+          done();
+        },
+      });
+
+    api.emit(EventName.error, new Error(testValue), -1, 1);
+  });
+
+  test("Incremental collection and complete event", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit historicalTicks events and verify all subscribers receive it
+
+    const firstTick: HistoricalTick = {
+      time: 12345,
+      price: 101,
+      size: 102,
+    };
+
+    const secondTick: HistoricalTick = {
+      time: 12346,
+      price: 201,
+      size: 202,
+    };
+
+    apiNext
+      .getHistoricalTicksMid({}, "", "", 1, 1)
+      // eslint-disable-next-line rxjs/no-ignored-subscription
+      .subscribe({
+        next: (ticks) => {
+          if (!ticks || !ticks.length || ticks.length > 2) {
+            fail();
+          }
+          if (ticks.length >= 1) {
+            expect(ticks[0].time).toEqual(firstTick.time);
+            expect(ticks[0].price).toEqual(firstTick.price);
+            expect(ticks[0].size).toEqual(firstTick.size);
+          }
+          if (ticks.length == 2) {
+            expect(ticks[1].time).toEqual(secondTick.time);
+            expect(ticks[1].price).toEqual(secondTick.price);
+            expect(ticks[1].size).toEqual(secondTick.size);
+          }
+        },
+        complete: () => {
+          done();
+        },
+        error: () => {
+          fail();
+        },
+      });
+
+    api.emit(EventName.historicalTicks, 1, [firstTick], false);
+    api.emit(EventName.historicalTicks, 1, [secondTick], true);
+  });
+});

--- a/src/tools/historical-data-updates.ts
+++ b/src/tools/historical-data-updates.ts
@@ -17,7 +17,7 @@ const USAGE_TEXT = "Usage: historical-data.js <options>";
 const OPTION_ARGUMENTS: [string, string][] = [
   [
     "conid=<number>",
-    "(required) Contract ID (conId) of contract to receive daily PnL updates for.",
+    "(required) Contract ID (conId) of contract to receive real-time bar updates for.",
   ],
   ["exchange=<name>", "The destination exchange name."],
   ["barSize=<durationString>", "(required) The data granularity."],

--- a/src/tools/historical-data.ts
+++ b/src/tools/historical-data.ts
@@ -12,11 +12,11 @@ import { IBApiNextApp } from "./common/ib-api-next-app";
 /////////////////////////////////////////////////////////////////////////////////
 
 const DESCRIPTION_TEXT = "Print historical chart data of a contract.";
-const USAGE_TEXT = "Usage: historical-data-updates.js <options>";
+const USAGE_TEXT = "Usage: historical-data.js <options>";
 const OPTION_ARGUMENTS: [string, string][] = [
   [
     "conid=<number>",
-    "(required) Contract ID (conId) of contract to receive daily PnL updates for.",
+    "(required) Contract ID (conId) of contract to receive historical chart data for.",
   ],
   ["exchange=<name>", "The destination exchange name."],
   [

--- a/src/tools/historical-ticks-bid-ask.ts
+++ b/src/tools/historical-ticks-bid-ask.ts
@@ -95,7 +95,7 @@ class PrintHistoricalTicksMidApp extends IBApiNextApp {
       )
       .subscribe({
         next: (ticks) => {
-          // this called each time a new tick arrives (e.g. to show a progress indicator,
+          // this is called each time a new ticks arrive from TWS (e.g. to show a progress indicator,
           // or to display results incrementally - we don't, but simply wait for complete)
           allTicks = ticks;
         },

--- a/src/tools/historical-ticks-bid-ask.ts
+++ b/src/tools/historical-ticks-bid-ask.ts
@@ -1,0 +1,125 @@
+/**
+ * This App will print historical bid / ask price Time&Sales data of and instrument.
+ */
+import path from "path";
+import { Subscription } from "rxjs";
+import { HistoricalTickBidAsk } from "..";
+
+import { IBApiNextError } from "../api-next";
+import logger from "../common/logger";
+import { IBApiNextApp } from "./common/ib-api-next-app";
+
+/////////////////////////////////////////////////////////////////////////////////
+// The help text                                                               //
+/////////////////////////////////////////////////////////////////////////////////
+
+const DESCRIPTION_TEXT =
+  "Print historical bid / ask price Time&Sales data of and instrument.";
+const USAGE_TEXT = "Usage: historical-ticks-mid.js <options>";
+const OPTION_ARGUMENTS: [string, string][] = [
+  [
+    "conid=<number>",
+    "(required) Contract ID (conId) of contract to receive historical bid / ask price Time&Sales data for.",
+  ],
+  ["exchange=<name>", "The destination exchange name."],
+  [
+    "start=<dateTimeString>",
+    "(required if -end not specified) The start date/time of the request. '20170701 12:01:00'. Uses TWS timezone specified at login.",
+  ],
+  [
+    "end=<dateTimeString>",
+    "(required if -start not specified) The end date/time of the request. '20170701 13:01:00'. In TWS timezone.",
+  ],
+  [
+    "count=<number>",
+    "(required) Number of distinct data points. Max 1000 per request.",
+  ],
+  [
+    "rth=<0/1>",
+    "(optional) Data from regular trading hours (1), or all available hours (0). Default is 1",
+  ],
+];
+const EXAMPLE_TEXT =
+  "historical-ticks-mid.js -conid=3691937 -exchange=SMART -start=20210604 16:00:00 -count=100";
+
+//////////////////////////////////////////////////////////////////////////////
+// The App code                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+class PrintHistoricalTicksMidApp extends IBApiNextApp {
+  constructor() {
+    super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
+  }
+
+  /** The [[Subscription]] on the historic ticks while being collected from TWS (list will grow incrementally). */
+  private subscription$: Subscription;
+
+  /**
+   * Start the the app.
+   */
+  start(): void {
+    const scriptName = path.basename(__filename);
+    logger.debug(`Starting ${scriptName} script`);
+
+    if (!this.cmdLineArgs.conid) {
+      this.error("-conid argument missing.");
+    }
+    if (!this.cmdLineArgs.exchange) {
+      this.error("-exchange argument missing.");
+    }
+    if (!this.cmdLineArgs.start && !this.cmdLineArgs.end) {
+      this.error("-start or -end argument missing.");
+    }
+    if (this.cmdLineArgs.start && this.cmdLineArgs.end) {
+      this.error("-start and -end argument specified, only use one of both.");
+    }
+    if (!this.cmdLineArgs.count) {
+      this.error("-count argument missing.");
+    }
+
+    this.connect();
+
+    let allTicks: HistoricalTickBidAsk[];
+
+    this.subscription$ = this.api
+      .getHistoricalTicksBidAsk(
+        {
+          conId: Number(this.cmdLineArgs.conid),
+          exchange: this.cmdLineArgs.exchange,
+        },
+        this.cmdLineArgs.start,
+        this.cmdLineArgs.end,
+        Number(this.cmdLineArgs.count),
+        Number(this.cmdLineArgs.rth === undefined ? 1 : this.cmdLineArgs.rth),
+        false
+      )
+      .subscribe({
+        next: (ticks) => {
+          // this called each time a new tick arrives (e.g. to show a progress indicator,
+          // or to display results incrementally - we don't, but simply wait for complete)
+          allTicks = ticks;
+        },
+        complete: () => {
+          this.printObject(allTicks);
+          this.stop();
+        },
+        error: (err: IBApiNextError) => {
+          this.error(
+            `getHistoricalTicksBidAsk failed with '${err.error.message}'`
+          );
+        },
+      });
+  }
+
+  /**
+   * Stop the the app with success code.
+   */
+  stop() {
+    this.subscription$?.unsubscribe();
+    this.exit();
+  }
+}
+
+// run the app
+
+new PrintHistoricalTicksMidApp().start();

--- a/src/tools/historical-ticks-last.ts
+++ b/src/tools/historical-ticks-last.ts
@@ -1,0 +1,124 @@
+/**
+ * This App will print historical last trade price Time&Sales data of and instrument.
+ */
+import path from "path";
+import { Subscription } from "rxjs";
+import { HistoricalTickLast } from "..";
+
+import { IBApiNextError } from "../api-next";
+import logger from "../common/logger";
+import { IBApiNextApp } from "./common/ib-api-next-app";
+
+/////////////////////////////////////////////////////////////////////////////////
+// The help text                                                               //
+/////////////////////////////////////////////////////////////////////////////////
+
+const DESCRIPTION_TEXT =
+  "Print historical last trade price Time&Sales data of and instrument.";
+const USAGE_TEXT = "Usage: historical-ticks-mid.js <options>";
+const OPTION_ARGUMENTS: [string, string][] = [
+  [
+    "conid=<number>",
+    "(required) Contract ID (conId) of contract to receive historical last trade price Time&Sales data for.",
+  ],
+  ["exchange=<name>", "The destination exchange name."],
+  [
+    "start=<dateTimeString>",
+    "(required if -end not specified) The start date/time of the request. '20170701 12:01:00'. Uses TWS timezone specified at login.",
+  ],
+  [
+    "end=<dateTimeString>",
+    "(required if -start not specified) The end date/time of the request. '20170701 13:01:00'. In TWS timezone.",
+  ],
+  [
+    "count=<number>",
+    "(required) Number of distinct data points. Max 1000 per request.",
+  ],
+  [
+    "rth=<0/1>",
+    "(optional) Data from regular trading hours (1), or all available hours (0). Default is 1",
+  ],
+];
+const EXAMPLE_TEXT =
+  "historical-ticks-mid.js -conid=3691937 -exchange=SMART -start=20210604 16:00:00 -count=100";
+
+//////////////////////////////////////////////////////////////////////////////
+// The App code                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+class PrintHistoricalTicksMidApp extends IBApiNextApp {
+  constructor() {
+    super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
+  }
+
+  /** The [[Subscription]] on the historic ticks while being collected from TWS (list will grow incrementally). */
+  private subscription$: Subscription;
+
+  /**
+   * Start the the app.
+   */
+  start(): void {
+    const scriptName = path.basename(__filename);
+    logger.debug(`Starting ${scriptName} script`);
+
+    if (!this.cmdLineArgs.conid) {
+      this.error("-conid argument missing.");
+    }
+    if (!this.cmdLineArgs.exchange) {
+      this.error("-exchange argument missing.");
+    }
+    if (!this.cmdLineArgs.start && !this.cmdLineArgs.end) {
+      this.error("-start or -end argument missing.");
+    }
+    if (this.cmdLineArgs.start && this.cmdLineArgs.end) {
+      this.error("-start and -end argument specified, only use one of both.");
+    }
+    if (!this.cmdLineArgs.count) {
+      this.error("-count argument missing.");
+    }
+
+    this.connect();
+
+    let allTicks: HistoricalTickLast[];
+
+    this.subscription$ = this.api
+      .getHistoricalTicksLast(
+        {
+          conId: Number(this.cmdLineArgs.conid),
+          exchange: this.cmdLineArgs.exchange,
+        },
+        this.cmdLineArgs.start,
+        this.cmdLineArgs.end,
+        Number(this.cmdLineArgs.count),
+        Number(this.cmdLineArgs.rth === undefined ? 1 : this.cmdLineArgs.rth)
+      )
+      .subscribe({
+        next: (ticks) => {
+          // this called each time a new tick arrives (e.g. to show a progress indicator,
+          // or to display results incrementally - we don't, but simply wait for complete)
+          allTicks = ticks;
+        },
+        complete: () => {
+          this.printObject(allTicks);
+          this.stop();
+        },
+        error: (err: IBApiNextError) => {
+          this.error(
+            `getHistoricalTicksBidAsk failed with '${err.error.message}'`
+          );
+        },
+      });
+  }
+
+  /**
+   * Stop the the app with success code.
+   */
+  stop() {
+    this.subscription$?.unsubscribe();
+    this.exit();
+  }
+}
+
+// run the app
+
+new PrintHistoricalTicksMidApp().start();

--- a/src/tools/historical-ticks-last.ts
+++ b/src/tools/historical-ticks-last.ts
@@ -46,7 +46,7 @@ const EXAMPLE_TEXT =
 // The App code                                                             //
 //////////////////////////////////////////////////////////////////////////////
 
-class PrintHistoricalTicksMidApp extends IBApiNextApp {
+class PrintHistoricalTicksLastApp extends IBApiNextApp {
   constructor() {
     super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
   }
@@ -94,7 +94,7 @@ class PrintHistoricalTicksMidApp extends IBApiNextApp {
       )
       .subscribe({
         next: (ticks) => {
-          // this called each time a new tick arrives (e.g. to show a progress indicator,
+          // this is called each time a new ticks arrive from TWS (e.g. to show a progress indicator,
           // or to display results incrementally - we don't, but simply wait for complete)
           allTicks = ticks;
         },
@@ -121,4 +121,4 @@ class PrintHistoricalTicksMidApp extends IBApiNextApp {
 
 // run the app
 
-new PrintHistoricalTicksMidApp().start();
+new PrintHistoricalTicksLastApp().start();

--- a/src/tools/historical-ticks-mid.ts
+++ b/src/tools/historical-ticks-mid.ts
@@ -1,0 +1,124 @@
+/**
+ * This App will print historical mid price Time&Sales data of and instrument.
+ */
+import path from "path";
+import { Subscription } from "rxjs";
+import { HistoricalTick } from "..";
+
+import { IBApiNextError } from "../api-next";
+import logger from "../common/logger";
+import { IBApiNextApp } from "./common/ib-api-next-app";
+
+/////////////////////////////////////////////////////////////////////////////////
+// The help text                                                               //
+/////////////////////////////////////////////////////////////////////////////////
+
+const DESCRIPTION_TEXT =
+  "Print historical mid price Time&Sales data of and instrument.";
+const USAGE_TEXT = "Usage: historical-ticks-mid.js <options>";
+const OPTION_ARGUMENTS: [string, string][] = [
+  [
+    "conid=<number>",
+    "(required) Contract ID (conId) of contract to receive historical mid price Time&Sales data for.",
+  ],
+  ["exchange=<name>", "The destination exchange name."],
+  [
+    "start=<dateTimeString>",
+    "(required if -end not specified) The start date/time of the request. '20170701 12:01:00'. Uses TWS timezone specified at login.",
+  ],
+  [
+    "end=<dateTimeString>",
+    "(required if -start not specified) The end date/time of the request. '20170701 13:01:00'. In TWS timezone.",
+  ],
+  [
+    "count=<number>",
+    "(required) Number of distinct data points. Max 1000 per request.",
+  ],
+  [
+    "rth=<0/1>",
+    "(optional) Data from regular trading hours (1), or all available hours (0). Default is 1",
+  ],
+];
+const EXAMPLE_TEXT =
+  "historical-ticks-mid.js -conid=3691937 -exchange=SMART -start=20210604 16:00:00 -count=100";
+
+//////////////////////////////////////////////////////////////////////////////
+// The App code                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+class PrintHistoricalTicksMidApp extends IBApiNextApp {
+  constructor() {
+    super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
+  }
+
+  /** The [[Subscription]] on the historic ticks while being collected from TWS (list will grow incrementally). */
+  private subscription$: Subscription;
+
+  /**
+   * Start the the app.
+   */
+  start(): void {
+    const scriptName = path.basename(__filename);
+    logger.debug(`Starting ${scriptName} script`);
+
+    if (!this.cmdLineArgs.conid) {
+      this.error("-conid argument missing.");
+    }
+    if (!this.cmdLineArgs.exchange) {
+      this.error("-exchange argument missing.");
+    }
+    if (!this.cmdLineArgs.start && !this.cmdLineArgs.end) {
+      this.error("-start or -end argument missing.");
+    }
+    if (this.cmdLineArgs.start && this.cmdLineArgs.end) {
+      this.error("-start and -end argument specified, only use one of both.");
+    }
+    if (!this.cmdLineArgs.count) {
+      this.error("-count argument missing.");
+    }
+
+    this.connect();
+
+    let allTicks: HistoricalTick[];
+
+    this.subscription$ = this.api
+      .getHistoricalTicksMid(
+        {
+          conId: Number(this.cmdLineArgs.conid),
+          exchange: this.cmdLineArgs.exchange,
+        },
+        this.cmdLineArgs.start,
+        this.cmdLineArgs.end,
+        Number(this.cmdLineArgs.count),
+        Number(this.cmdLineArgs.rth === undefined ? 1 : this.cmdLineArgs.rth)
+      )
+      .subscribe({
+        next: (ticks) => {
+          // this called each time a new tick arrives (e.g. to show a progress indicator,
+          // or to display results incrementally - we don't, but simply wait for complete)
+          allTicks = ticks;
+        },
+        complete: () => {
+          this.printObject(allTicks);
+          this.stop();
+        },
+        error: (err: IBApiNextError) => {
+          this.error(
+            `getHistoricalTicksMid failed with '${err.error.message}'`
+          );
+        },
+      });
+  }
+
+  /**
+   * Stop the the app with success code.
+   */
+  stop() {
+    this.subscription$?.unsubscribe();
+    this.exit();
+  }
+}
+
+// run the app
+
+new PrintHistoricalTicksMidApp().start();

--- a/src/tools/historical-ticks-mid.ts
+++ b/src/tools/historical-ticks-mid.ts
@@ -94,7 +94,7 @@ class PrintHistoricalTicksMidApp extends IBApiNextApp {
       )
       .subscribe({
         next: (ticks) => {
-          // this called each time a new tick arrives (e.g. to show a progress indicator,
+          // this is called each time a new ticks arrive from TWS (e.g. to show a progress indicator,
           // or to display results incrementally - we don't, but simply wait for complete)
           allTicks = ticks;
         },


### PR DESCRIPTION
Follow-up PR to https://github.com/stoqey/ib/pull/88 to get historic ticks fully supported.
Fixes:
- Fix HISTORICAL_TICKS decoder

New added functions:
```
IBApiNext.getHistoricalTicksMid(
    contract: Contract,
    startDateTime: string,
    endDateTime: string,
    numberOfTicks: number,
    useRTH: number
  ): Observable<HistoricalTick[]>
```
```
IBApiNext.getHistoricalTicksBidAsk(
    contract: Contract,
    startDateTime: string,
    endDateTime: string,
    numberOfTicks: number,
    useRTH: number,
    ignoreSize: boolean
  ): Observable<HistoricalTickBidAsk[]>
```
```
IBApiNext.getHistoricalTicksLast(
    contract: Contract,
    startDateTime: string,
    endDateTime: string,
    numberOfTicks: number,
    useRTH: number
  ): Observable<HistoricalTickLast[]>
```

New added tools:
- /dist/tools/historical-ticks-mid.js
- /dist/tools/historical-ticks-bid-ask.js
- /dist/tools/historical-ticks-last.js

New added tests (RxJS wrappers only):
- get-historical-ticks-mid.test.ts
- get-historical-ticks-bid-ask.test.ts
- get-historical-ticks-last.test.ts

Documentation is also updated.