### PR TITLE
Update to RxJS 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,20 +122,21 @@ ib.reqIds();
 
 ## IBApiNext and RxJS
 
-While IBApi uses a request function / event callback design where subscriptions are managed by the user, IBApiNext does use RxJS 7 to manage subscriptions .\
-In general, there are four type of functions on IBApiNext:
+While IBApi uses a request function / event callback design where subscriptions are managed by the user, IBApiNext does use RxJS 7 to manage subscriptions.\
+In general, there are four types of functions on IBApiNext:
 
 - On-shot functions, returning a Promise, such as `IBApiNext.getCurrentTime`. Such functions will send a request to TWS and return the result (or error) on the Promise.
 
-- On-shot functions, returning an Observable, such as `IBApiNext.getContractDetails`. Such functions will send a request to TWS and invoke the `next` callback while collecting results from TWS. After all results
-  have been collected, `complete` callback will be invoked. The `next` callback can be used to show progress information, or display results incrementally, while new ones are still being collected.\
+- On-shot functions, returning an Observable, such as `IBApiNext.getContractDetails`. Such functions will send a request to TWS and invoke the `next` callback while collecting results from TWS. After all results have been collected, `complete` callback will be invoked. The `next` callback can be used to show progress information, or display results incrementally, while new ones are still being collected.\
   If you are not interested on incremental update events, but only on the final result-set, use the RxJS `lastValueFrom()` (example `lastValueFrom(IBApiNext.getContractDetails(contract))`) to convert the Observable into a Promise.
 
-- Functions that collect a set of values first and continue to deliver updates after colleted initially, such as `IBApiNext.getAccountSummary`. Such functions will send a request to TWS and invoke the `next` callback while collecting results from TWS. After all values have been collected, `complete` callback will be invoked. With each update after the initial collection, the `next` callback will invoked be invoked again.\
+- Functions that collect a set of values first and continue to deliver updates after colleted initially, such as `IBApiNext.getAccountSummary`.
+  Such functions will send a request to TWS and invoke the `next` callback while collecting results from TWS.
+  After all values have been collected, `complete` callback will be invoked. With each update after the initial collection, the `next` callback will invoked be invoked again.\
   Note that you can convert this to a Promise, using `lastValueFrom()`, however the Promise will resolve after the initial set of values is collected and subscription will be canceled afterwards (you will not receive any updates).
 
 - Endless stream subscriptions, returning an Observable, such `IBApiNext.getMarketData`.
-  Such functions will deliver an endless stream of update events. The `complete` callback NEVER be invoked (do not try to convert to a Promise - it will never resolve!)
+  Such functions will deliver an endless stream of update events. The `complete` callback will NEVER be invoked (do not try to convert to a Promise - it will never resolve!)
 
 ## IB-Shell / IBApiNext Examples
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or
 There are two APIs on this package, IBApi and IBApiNext.
 
 IBApi replicates the official TWS API as close as possible, making it easy to migrate or port existing code.
-It implements all functions and provies same event callbacks as the official TWS API does.
+It implements all functions and provides same event callbacks as the official TWS API does.
 
 IBApiNext is a **preview** of a new API that is currently in development.
 The goal of IBApiNext is it, to provide same functionality as IBApi, but focus on usability rather than replicating the official interface.
@@ -75,17 +75,17 @@ let positionsCount = 0;
 ib.on(EventName.error, (err: Error, code: ErrorCode, reqId: number) => {
   console.error(`${err.message} - code: ${code} - reqId: ${reqId}`);
 })
-.on(
-  EventName.position,
-  (account: string, contract: Contract, pos: number, avgCost: number) => {
-    console.log(`${account}: ${pos} x ${contract.symbol} @ ${avgCost}`);
-    positionsCount++;
-  }
-)
-.once(EventName.positionEnd, () => {
-  console.log(`Total: ${positionsCount} positions.`);
-  ib.disconnect();
-});
+  .on(
+    EventName.position,
+    (account: string, contract: Contract, pos: number, avgCost: number) => {
+      console.log(`${account}: ${pos} x ${contract.symbol} @ ${avgCost}`);
+      positionsCount++;
+    }
+  )
+  .once(EventName.positionEnd, () => {
+    console.log(`Total: ${positionsCount} positions.`);
+    ib.disconnect();
+  });
 
 // call API functions
 
@@ -97,28 +97,45 @@ ib.reqPositions();
 
 ```js
 ib.once(EventName.nextValidId, (orderId: number) => {
-    const contract: Contract = {
-      symbol: "AMZN",
-      exchange: "SMART",
-      currency: "USD",
-      secType: SecType.STK,
-    };
+  const contract: Contract = {
+    symbol: "AMZN",
+    exchange: "SMART",
+    currency: "USD",
+    secType: SecType.STK,
+  };
 
-    const order: Order = {
-      orderType: OrderType.LMT,
-      action: OrderAction.BUY,
-      lmtPrice: 1,
-      orderId,
-      totalQuantity: 1,
-      account: 'YOUR_ACCOUNT_ID'
-    };
+  const order: Order = {
+    orderType: OrderType.LMT,
+    action: OrderAction.BUY,
+    lmtPrice: 1,
+    orderId,
+    totalQuantity: 1,
+    account: "YOUR_ACCOUNT_ID",
+  };
 
-    ib.placeOrder(orderId, contract, order);
-  });
+  ib.placeOrder(orderId, contract, order);
+});
 
 ib.connect();
 ib.reqIds();
 ```
+
+## IBApiNext and RxJS
+
+While IBApi uses a request function / event callback design where subscriptions are managed by the user, IBApiNext does use RxJS 7 to manage subscriptions .\
+In general, there are four type of functions on IBApiNext:
+
+- On-shot functions, returning a Promise, such as `IBApiNext.getCurrentTime`. Such functions will send a request to TWS and return the result (or error) on the Promise.
+
+- On-shot functions, returning an Observable, such as `IBApiNext.getContractDetails`. Such functions will send a request to TWS and invoke the `next` callback while collecting results from TWS. After all results
+  have been collected, `complete` callback will be invoked. The `next` callback can be used to show progress information, or display results incrementally, while new ones are still being collected.\
+  If you are not interested on incremental update events, but only on the final result-set, use the RxJS `lastValueFrom()` (example `lastValueFrom(IBApiNext.getContractDetails(contract))`) to convert the Observable into a Promise.
+
+- Functions that collect a set of values first and continue to deliver updates after colleted initially, such as `IBApiNext.getAccountSummary`. Such functions will send a request to TWS and invoke the `next` callback while collecting results from TWS. After all values have been collected, `complete` callback will be invoked. With each update after the initial collection, the `next` callback will invoked be invoked again.\
+  Note that you can convert this to a Promise, using `lastValueFrom()`, however the Promise will resolve after the initial set of values is collected and subscription will be canceled afterwards (you will not receive any updates).
+
+- Endless stream subscriptions, returning an Observable, such `IBApiNext.getMarketData`.
+  Such functions will deliver an endless stream of update events. The `complete` callback NEVER be invoked (do not try to convert to a Promise - it will never resolve!)
 
 ## IB-Shell / IBApiNext Examples
 
@@ -208,4 +225,3 @@ In addition to that, a little demo / example app would be nice, to demonstrate A
 Any kind of bugfixes are welcome as well.
 
 If you want to contribute, read the [Developer Guide](https://github.com/stoqey/ib/wiki/Developer-Guide) and start coding.
-

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ In general, there are four types of functions on IBApiNext:
 
 - Functions that collect a set of values first and continue to deliver updates after colleted initially, such as `IBApiNext.getAccountSummary`.
   Such functions will send a request to TWS and invoke the `next` callback while collecting results from TWS.
-  After all values have been collected, `complete` callback will be invoked. With each update after the initial collection, the `next` callback will invoked be invoked again.\
+  After all values have been collected, `complete` callback will be invoked. With each update after the initial collection, the `next` callback will be invoked again.\
   Note that you can convert this to a Promise, using `lastValueFrom()`, however the Promise will resolve after the initial set of values is collected and subscription will be canceled afterwards (you will not receive any updates).
 
 - Endless stream subscriptions, returning an Observable, such `IBApiNext.getMarketData`.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tsc": "./node_modules/.bin/tsc"
   },
   "engines": {
-    "node": ">=14.17.0"
+    "node": ">=4.2.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
     "dotenv": "^8.2.0",
     "eventemitter3": "^4.0.7",
     "function-rate-limit": "^1.1.0",
-    "rxjs": "^6.6.3"
+    "rxjs": "^7.1.0"
   }
 }

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject } from "rxjs";
+import { lastValueFrom, Observable, Subject } from "rxjs";
 import { map, take } from "rxjs/operators";
 import {
   Bar,
@@ -305,19 +305,20 @@ export class IBApiNext {
    * Get TWS's current time.
    */
   getCurrentTime(): Promise<number> {
-    return this.subscriptions
-      .register<number>(
-        () => {
-          this.api.reqCurrentTime();
-        },
-        undefined,
-        [[EventName.currentTime, this.onCurrentTime]]
-      )
-      .pipe(
-        take(1),
-        map((v: { all: any }) => v.all)
-      )
-      .toPromise();
+    return lastValueFrom(
+      this.subscriptions
+        .register<number>(
+          () => {
+            this.api.reqCurrentTime();
+          },
+          undefined,
+          [[EventName.currentTime, this.onCurrentTime]]
+        )
+        .pipe(
+          take(1),
+          map((v: { all: number }) => v.all)
+        )
+    );
   }
 
   /** managedAccounts event handler.  */
@@ -333,19 +334,20 @@ export class IBApiNext {
    * Get the accounts to which the logged user has access to.
    */
   getManagedAccounts(): Promise<string[]> {
-    return this.subscriptions
-      .register<string[]>(
-        () => {
-          this.api.reqManagedAccts();
-        },
-        undefined,
-        [[EventName.managedAccounts, this.onManagedAccts]]
-      )
-      .pipe(
-        take(1),
-        map((v: { all: string[] }) => v.all)
-      )
-      .toPromise();
+    return lastValueFrom(
+      this.subscriptions
+        .register<string[]>(
+          () => {
+            this.api.reqManagedAccts();
+          },
+          undefined,
+          [[EventName.managedAccounts, this.onManagedAccts]]
+        )
+        .pipe(
+          take(1),
+          map((v: { all: string[] }) => v.all)
+        )
+    );
   }
 
   /** accountSummary event handler */
@@ -1231,27 +1233,28 @@ export class IBApiNext {
     useRTH: number,
     formatDate: number
   ): Promise<Bar[]> {
-    return this.subscriptions
-      .register<Bar[]>(
-        (reqId) => {
-          this.api.reqHistoricalData(
-            reqId,
-            contract,
-            endDateTime,
-            durationStr,
-            barSizeSetting,
-            whatToShow,
-            useRTH,
-            formatDate,
-            false
-          );
-        },
-        undefined,
-        [[EventName.historicalData, this.onHistoricalData]],
-        undefined
-      )
-      .pipe(map((v: { all: Bar[] }) => v.all))
-      .toPromise();
+    return lastValueFrom(
+      this.subscriptions
+        .register<Bar[]>(
+          (reqId) => {
+            this.api.reqHistoricalData(
+              reqId,
+              contract,
+              endDateTime,
+              durationStr,
+              barSizeSetting,
+              whatToShow,
+              useRTH,
+              formatDate,
+              false
+            );
+          },
+          undefined,
+          [[EventName.historicalData, this.onHistoricalData]],
+          undefined
+        )
+        .pipe(map((v: { all: Bar[] }) => v.all))
+    );
   }
 
   /** historicalDataUpdate event handler */

--- a/src/tools/account-summary.ts
+++ b/src/tools/account-summary.ts
@@ -6,7 +6,6 @@ import path from "path";
 import { Subscription } from "rxjs";
 
 import { IBApiNextError } from "../api-next";
-import LogLevel from "../api/data/enum/log-level";
 import logger from "../common/logger";
 import { IBApiNextApp } from "./common/ib-api-next-app";
 

--- a/src/tools/pnl-single.ts
+++ b/src/tools/pnl-single.ts
@@ -54,24 +54,26 @@ class PrintPositionsApp extends IBApiNextApp {
     if (!this.cmdLineArgs.conid) {
       this.error("-conid argument missing.");
     }
+
     this.connect(this.cmdLineArgs.watch ? 10000 : 0);
+
     this.subscription$ = this.api
       .getPnLSingle(
         this.cmdLineArgs.account,
         this.cmdLineArgs.model,
         Number(this.cmdLineArgs.conid)
       )
-      .subscribe(
-        (pnlSingle) => {
+      .subscribe({
+        next: (pnlSingle) => {
           this.printObject(pnlSingle);
           if (!this.cmdLineArgs.watch) {
             this.stop();
           }
         },
-        (err: IBApiNextError) => {
+        error: (err: IBApiNextError) => {
           this.error(`getPnLSingle failed with '${err.error.message}'`);
-        }
-      );
+        },
+      });
   }
 
   /**

--- a/src/tools/pnl.ts
+++ b/src/tools/pnl.ts
@@ -46,20 +46,22 @@ class PrintPositionsApp extends IBApiNextApp {
     if (!this.cmdLineArgs.account) {
       this.error("-account argument missing.");
     }
+
     this.connect(this.cmdLineArgs.watch ? 10000 : 0);
+
     this.subscription$ = this.api
       .getPnL(this.cmdLineArgs.account, this.cmdLineArgs.model)
-      .subscribe(
-        (pnl) => {
+      .subscribe({
+        next: (pnl) => {
           this.printObject(pnl);
           if (!this.cmdLineArgs.watch) {
             this.stop();
           }
         },
-        (err: IBApiNextError) => {
+        error: (err: IBApiNextError) => {
           this.error(`getPnL failed with '${err.error.message}'`);
-        }
-      );
+        },
+      });
   }
 
   /**

--- a/src/tools/positions.ts
+++ b/src/tools/positions.ts
@@ -44,17 +44,17 @@ class PrintPositionsApp extends IBApiNextApp {
     const scriptName = path.basename(__filename);
     logger.debug(`Starting ${scriptName} script`);
     this.connect(this.cmdLineArgs.watch ? 10000 : 0);
-    this.subscription$ = this.api.getPositions().subscribe(
-      (positions) => {
+    this.subscription$ = this.api.getPositions().subscribe({
+      next: (positions) => {
         this.printObject(positions);
         if (!this.cmdLineArgs.watch) {
           this.stop();
         }
       },
-      (err: IBApiNextError) => {
+      error: (err: IBApiNextError) => {
         this.error(`getPositions failed with '${err.error.message}'`);
-      }
-    );
+      },
+    });
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,12 +3533,12 @@ rxjs-report-usage@^1.0.4:
     glob "~7.1.6"
     prompts "~2.3.2"
 
-rxjs@^6.6.3:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+rxjs@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.1.0.tgz#94202d27b19305ef7b1a4f330277b2065df7039e"
+  integrity sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==
   dependencies:
-    tslib "^1.9.0"
+    tslib "~2.1.0"
 
 safe-buffer@~5.1.1:
   version "5.1.2"
@@ -3985,7 +3985,7 @@ ts-jest@^26.5.5:
     semver "7.x"
     yargs-parser "20.x"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -3994,6 +3994,11 @@ tslib@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils-etc@^1.0.0, tsutils-etc@^1.3.4:
   version "1.3.4"


### PR DESCRIPTION
Update to RxJX 7.

Changes:
- Obersable.toPromise has been deprecated. Replaced with `lastValueFrom`
I have added some extra comment to tools code that us lastValueFrom, to explain that you could also get incremental updates instead of waiting for complete / lastValueFrom.
- Added a new section to README, explaining different type of IBApiNext functions and how to use lastValueFrom with it.
