### PR TITLE
IBApiNext code cleanup

### DIFF
--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1,5 +1,5 @@
 import { lastValueFrom, Observable, Subject } from "rxjs";
-import { map, take } from "rxjs/operators";
+import { map } from "rxjs/operators";
 import {
   Bar,
   Contract,
@@ -303,7 +303,6 @@ export class IBApiNext {
       sub.next({ all: time });
       sub.complete();
     });
-    subscriptions.clear();
   };
 
   /**
@@ -317,12 +316,10 @@ export class IBApiNext {
             this.api.reqCurrentTime();
           },
           undefined,
-          [[EventName.currentTime, this.onCurrentTime]]
+          [[EventName.currentTime, this.onCurrentTime]],
+          "reqCurrentTime" // use same instance id each time, to make sure there is only 1 pending request at time
         )
-        .pipe(
-          take(1),
-          map((v: { all: number }) => v.all)
-        )
+        .pipe(map((v: { all: number }) => v.all))
     );
   }
 
@@ -332,8 +329,10 @@ export class IBApiNext {
     accountsList: string
   ): void => {
     const accounts = accountsList.split(",");
-    subscriptions.forEach((sub) => sub.next({ all: accounts }));
-    subscriptions.clear();
+    subscriptions.forEach((sub) => {
+      sub.next({ all: accounts });
+      sub.complete();
+    });
   };
 
   /**
@@ -347,12 +346,10 @@ export class IBApiNext {
             this.api.reqManagedAccts();
           },
           undefined,
-          [[EventName.managedAccounts, this.onManagedAccts]]
+          [[EventName.managedAccounts, this.onManagedAccts]],
+          "getManagedAccounts" // use same instance id each time, to make sure there is only 1 pending request at time
         )
-        .pipe(
-          take(1),
-          map((v: { all: string[] }) => v.all)
-        )
+        .pipe(map((v: { all: string[] }) => v.all))
     );
   }
 
@@ -1585,7 +1582,6 @@ export class IBApiNext {
       });
       sub.complete();
     });
-    subscriptions.clear();
   };
 
   /**
@@ -1600,7 +1596,7 @@ export class IBApiNext {
           },
           undefined,
           [[EventName.mktDepthExchanges, this.onMktDepthExchanges]],
-          undefined
+          "reqMktDepthExchanges" // use same instance id each time, to make sure there is only 1 pending request at time
         )
         .pipe(map((v: { all: DepthMktDataDescription[] }) => v.all))
     );


### PR DESCRIPTION
Does some code cleanup on IBApiNext code:

As discussed on slack:
- Remove take(1) operators on pipes. There is no more need for it, as it handled by .complete() call + lastValueFrom now.

As discussed on slack:
- Remove unnecessary subscriptions.clear() on callbacks, subscriptions will cleanup itself after completed.

During discussion on slack this came to my mind:
If you run a one-host Promise function, like getCurrentTime() 100x times in a loop, we will send 100 reqCurrentTime to TWS and first response will resolve it all.. => there is no real point on sending 100 reqCurrentTime. The first getCurrentTime() should send reqCurrentTime and all other 99 getCurrentTime() should just join waiting for response, instance of sending same request again. Solve that by using a hard-coded subscription instanceId, so will re-cycle any pending subscription if there is one, instead of creating a new one:
- One-shot function that return a Promise (such as getCurrentTime()) now use a static instanceId.
It does not make much sense to fire multiple requests of the time type to TWS, while the result of a previous one is still pending.
We re-use the subscription now, by using same instanceId on every call.
