### PR TITLE
IBApiNext: Add support for placing orders

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -323,14 +323,14 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Tool: next-unused-order-id",
+      "name": "Tool: next-valid-order-id",
       "skipFiles": [
         "<node_internals>/**"
       ],
       "runtimeArgs": [
         "--trace-warnings"
       ],
-      "program": "${workspaceFolder}/dist/tools/next-unused-order-id.js",
+      "program": "${workspaceFolder}/dist/tools/next-valid-order-id.js",
       "args": [
         "-port=4002"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -320,5 +320,25 @@
         "!**/node_modules/**"
       ]
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tool: next-unused-order-id",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "--trace-warnings"
+      ],
+      "program": "${workspaceFolder}/dist/tools/next-unused-order-id.js",
+      "args": [
+        "-port=4002"
+      ],
+      "outputCapture": "std",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
   ]
 }

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1666,11 +1666,12 @@ export class IBApiNext {
     // we only want to complete one subscription at a time,
     // to avoid multiple getNextValidOrderId calls to return same value
     const next = subscriptions.entries().next();
-    if (next && !next.done && next.value[1]) {
+    if (next && !next.done) {
       next.value[1].next({
         all: orderId,
       });
       next.value[1].complete();
+      subscriptions.delete(next.value[0]);
     }
   };
 

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -15,6 +15,7 @@ export interface Configuration {
   // package config
   ib_host: string;
   ib_port: number;
+  ib_test_account: string;
   default_client_id: number;
   client_version: number;
   max_req_per_second: number;
@@ -29,7 +30,7 @@ export interface Configuration {
 
 let configuration: Configuration = null;
 
-const envsToInclude = ["ci", "env_config_test", "ib_host", "ib_port", "client_version", "max_req_per_second"];
+const envsToInclude = ["ci", "env_config_test", "ib_host", "ib_port", "ib_test_account", "client_version", "max_req_per_second"];
 
 function readJson(readPath: string) {
   try {

--- a/src/tests/unit/api-next/danger/place-order.test.ts
+++ b/src/tests/unit/api-next/danger/place-order.test.ts
@@ -1,0 +1,30 @@
+import IBApi, { IBApiNext, OrderAction, OrderType } from "../../../..";
+import { Contract } from "../../../../api/contract/contract";
+import SecType from "../../../../api/data/enum/sec-type";
+import { Order } from "../../../../api/order/order";
+import configuration from "../../../../common/configuration";
+
+describe('Place orders to IB', () => {
+  test("Error Event", async (done) => {
+    const apiNext = new IBApiNext({host: configuration.ib_host, port: configuration.ib_port});
+    const api = ((apiNext as unknown) as Record<string, unknown>).api as IBApi;
+
+    const contract: Contract = { currency: "USD", symbol: "CARS", secType: SecType.STK }
+    const orderId = await apiNext.getNextValidOrderId();
+
+    const order: Order = {
+      orderType: OrderType.LMT,
+        action: OrderAction.BUY,
+        lmtPrice: 1,
+        orderId,
+        totalQuantity: 1,
+        account: configuration.ib_test_account,
+        conditionsIgnoreRth: true,
+    }
+
+    apiNext
+      .placeOrder(orderId, contract, order)
+
+
+  });
+});

--- a/src/tests/unit/api-next/next-valid-order-id.test.ts
+++ b/src/tests/unit/api-next/next-valid-order-id.test.ts
@@ -1,0 +1,30 @@
+/**
+ * This file implements tests for the [[IBApiNext.getCurrentTime]] function.
+ */
+
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
+
+describe("RxJS Wrapper: getNextUnusedOrderId()", () => {
+  test("Promise result", (done) => {
+    // create IBApiNext
+
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit a EventName.nextValidId and verify RxJS result
+
+    const testValue = Math.random();
+
+    apiNext
+      .getNextValidOrderId()
+      .then((time) => {
+        expect(time).toEqual(testValue);
+        done();
+      })
+      .catch((error: IBApiNextError) => {
+        fail(error.error.message);
+      });
+
+    api.emit(EventName.nextValidId, testValue);
+  });
+});

--- a/src/tests/unit/api/order/placeOrder.test.ts
+++ b/src/tests/unit/api/order/placeOrder.test.ts
@@ -6,13 +6,14 @@ import {
     PriceCondition, SecType, TriggerMethod
 } from "../../../..";
 import OptionType from "../../../../api/data/enum/option-type";
+import configuration from "../../../../common/configuration";
 
 describe("RequestAllOpenOrders", () => {
   jest.setTimeout(20000);
 
   test("placeOrder with PriceCondition", (done) => {
     const ib = new IBApi({
-      port: 4002, // use Gateway
+      port: configuration.ib_port, // use Gateway
     });
 
     ib.on(EventName.error, (error: Error, _code: ErrorCode, _reqId: number) => {

--- a/src/tools/next-valid-order-id.ts
+++ b/src/tools/next-valid-order-id.ts
@@ -1,0 +1,53 @@
+/**
+ * This App will print the next valid unused order id.
+ */
+
+import path from "path";
+
+import { IBApiNextError } from "../api-next";
+import logger from "../common/logger";
+import { IBApiNextApp } from "./common/ib-api-next-app";
+
+/////////////////////////////////////////////////////////////////////////////////
+// Help text and command line parsing                                          //
+/////////////////////////////////////////////////////////////////////////////////
+
+const DESCRIPTION_TEXT = "Prints the next valid unused order id.";
+const USAGE_TEXT = "Usage: next-valid-order-id.js <options>";
+const OPTION_ARGUMENTS: [string, string][] = [];
+const EXAMPLE_TEXT = "next-valid-order-id.js -host=localhost -port=4002";
+
+//////////////////////////////////////////////////////////////////////////////
+// The App code                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+class PrintNextUnusedOrderIdApp extends IBApiNextApp {
+  constructor() {
+    super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
+  }
+
+  /**
+   * Start the the app.
+   */
+  start(): void {
+    const scriptName = path.basename(__filename);
+    logger.debug(`Starting ${scriptName} script`);
+    this.connect(0);
+
+    // print next unused order id
+
+    this.api
+      .getNextValidOrderId()
+      .then((id) => {
+        this.printText(`${id}`);
+        this.exit();
+      })
+      .catch((err: IBApiNextError) => {
+        this.error(`getNextValidOrderId failed with '${err.error.message}'`);
+      });
+  }
+}
+
+// run the app
+
+new PrintNextUnusedOrderIdApp().start();


### PR DESCRIPTION
New functions:

```
- IBApiNext.getNextValidOrderId(): Promise<number>
- IBApiNext.placeOrder(id: number, contract: Contract, order: Order): void
```

New tools:

- next-valid-order-id.js

New tests (RxJS wrappers only):

- next-valid-order-id.test.ts

Note that there is no tool for placeOrder yet, as it would be huge if we want cover all kind of different order types and conditions. If you want to add some simple place-buy-limit-order.ts tool, feel free - otherwise it's fine for me to not have tool(s) for placing orders as for now.