### PR TITLE
IBApiNext: add getHeadTimestamp

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -320,5 +320,29 @@
         "!**/node_modules/**"
       ]
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tool: get-head-timestamp",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "--trace-warnings"
+      ],
+      "program": "${workspaceFolder}/dist/tools/get-head-timestamp.js",
+      "args": [
+        "-symbol=AMZN",
+        "-sectype=STK",
+        "-exchange=SMART",
+        "-conid=3691937",
+        "-port=4002"
+      ],
+      "outputCapture": "std",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
   ]
 }

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1131,14 +1131,12 @@ export class IBApiNext {
     headTimestamp: string
   ): void => {
     // get subscription
-
     const subscription = subscriptions.get(reqId);
     if (!subscription) {
       return;
     }
 
     // signal timestamp
-
     subscription.next({ all: headTimestamp });
     subscription.complete();
   };

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1658,7 +1658,7 @@ export class IBApiNext {
     );
   }
 
-  /** mktDepthExchanges event handler */
+  /** histogramData event handler */
   private readonly onHistogramData = (
     subscriptions: Map<number, IBApiNextSubscription<HistogramEntry[]>>,
     reqId: number,

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -285,7 +285,7 @@ export class IBApi extends EventEmitter {
    *
    * @param tickerId The request's identifier.
    *
-   * @see [[reqHistoricalData]]
+   * @see [[reqHistogramData]]
    */
   cancelHistogramData(tickerId: number): IBApi {
     this.controller.schedule(() =>
@@ -2112,7 +2112,7 @@ export declare interface IBApi {
    * The time zone of the bar is the time zone chosen on the TWS login screen.
    * Smallest bar size is 1 second.
    *
-   * @see [[reqHistogramData]]
+   * @see [[reqHistoricalData]]
    */
   on(
     event: EventName.historicalDataUpdate,

--- a/src/core/io/encoder.ts
+++ b/src/core/io/encoder.ts
@@ -1695,8 +1695,8 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
       OUT_MSG_ID.REQ_HEAD_TIMESTAMP,
       reqId,
       this.encodeContract(contract),
-      useRTH,
       whatToShow,
+      useRTH ? 1 : 0,
       formatDate
     );
   }

--- a/src/tests/unit/api-next/get-head-timestamp.test.ts
+++ b/src/tests/unit/api-next/get-head-timestamp.test.ts
@@ -7,14 +7,11 @@ import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
 describe("RxJS Wrapper: getHeadTimestamp()", () => {
   test("Promise result", (done) => {
     // create IBApiNext
-
     const apiNext = new IBApiNext();
     const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
 
     // emit a EventName.headTimestamp and verify RxJS result
-
     const testValue = Math.random();
-
     apiNext
       .getHeadTimestamp({}, "TRADES", true, 1)
       .then((time) => {

--- a/src/tests/unit/api-next/get-head-timestamp.test.ts
+++ b/src/tests/unit/api-next/get-head-timestamp.test.ts
@@ -1,0 +1,30 @@
+/**
+ * This file implements tests for the [[IBApiNext.getHeadTimestamp]] function.
+ */
+
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
+
+describe("RxJS Wrapper: getHeadTimestamp()", () => {
+  test("Promise result", (done) => {
+    // create IBApiNext
+
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit a EventName.headTimestamp and verify RxJS result
+
+    const testValue = Math.random();
+
+    apiNext
+      .getHeadTimestamp({}, "TRADES", true, 1)
+      .then((time) => {
+        expect(time).toEqual(testValue);
+        done();
+      })
+      .catch((error: IBApiNextError) => {
+        fail(error.error.message);
+      });
+
+    api.emit(EventName.headTimestamp, 1, testValue);
+  });
+});

--- a/src/tools/get-head-timestamp.ts
+++ b/src/tools/get-head-timestamp.ts
@@ -54,7 +54,6 @@ class PrintHeadTimestampApp extends IBApiNextApp {
     this.connect(0);
 
     // print next unused order id
-
     this.api
       .getHeadTimestamp(
         {
@@ -82,5 +81,4 @@ class PrintHeadTimestampApp extends IBApiNextApp {
 }
 
 // run the app
-
 new PrintHeadTimestampApp().start();

--- a/src/tools/get-head-timestamp.ts
+++ b/src/tools/get-head-timestamp.ts
@@ -3,8 +3,8 @@
  */
 
 import path from "path";
-import { OptionType, SecType } from "..";
 
+import { OptionType, SecType } from "../";
 import { IBApiNextError } from "../api-next";
 import logger from "../common/logger";
 import { IBApiNextApp } from "./common/ib-api-next-app";
@@ -34,7 +34,7 @@ const OPTION_ARGUMENTS: [string, string][] = [
   ["right=<P|C>", " The option type. Valid values are P, PUT, C, CALL."],
 ];
 const EXAMPLE_TEXT =
-  "get-head-timestamp.js -symbol=AMZN -sectype=STK -currency=USD -port=4002";
+  "get-head-timestamp.js -symbol=AMZN -sectype=STK -currency=USD -exchange=SMART -conid=3691937 -port=4002";
 
 //////////////////////////////////////////////////////////////////////////////
 // The App code                                                             //

--- a/src/tools/get-head-timestamp.ts
+++ b/src/tools/get-head-timestamp.ts
@@ -1,0 +1,86 @@
+/**
+ * This App will print the timestamp of earliest available historical data for a contract.
+ */
+
+import path from "path";
+import { OptionType, SecType } from "..";
+
+import { IBApiNextError } from "../api-next";
+import logger from "../common/logger";
+import { IBApiNextApp } from "./common/ib-api-next-app";
+
+/////////////////////////////////////////////////////////////////////////////////
+// Help text and command line parsing                                          //
+/////////////////////////////////////////////////////////////////////////////////
+
+const DESCRIPTION_TEXT =
+  "Prints the timestamp of earliest available historical data for a contract.";
+const USAGE_TEXT = "Usage: get-head-timestamp.js <options>";
+const OPTION_ARGUMENTS: [string, string][] = [
+  ["conid=<number>", "Contract ID (conId) of the contract."],
+  ["symbol=<name>", "The symbol name."],
+  [
+    "sectype=<type>",
+    "The security type. Valid values: STK, OPT, FUT, IND, FOP, CFD, CASH, BAG, BOND, CMDTY, NEWS and FUND",
+  ],
+  ["exchange=<name>", "The destination exchange name."],
+  ["currency=<currency>", "The contract currency."],
+  [
+    "expiry=<YYYYMM>",
+    "The contract's last trading day or contract month (for Options and Futures)." +
+      "Strings with format YYYYMM will be interpreted as the Contract Month whereas YYYYMMDD will be interpreted as Last Trading Day.",
+  ],
+  ["strike=<number>", "The option's strike price."],
+  ["right=<P|C>", " The option type. Valid values are P, PUT, C, CALL."],
+];
+const EXAMPLE_TEXT =
+  "get-head-timestamp.js -symbol=AMZN -sectype=STK -currency=USD -port=4002";
+
+//////////////////////////////////////////////////////////////////////////////
+// The App code                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+class PrintHeadTimestampApp extends IBApiNextApp {
+  constructor() {
+    super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
+  }
+
+  /**
+   * Start the the app.
+   */
+  start(): void {
+    const scriptName = path.basename(__filename);
+    logger.debug(`Starting ${scriptName} script`);
+    this.connect(0);
+
+    // print next unused order id
+
+    this.api
+      .getHeadTimestamp(
+        {
+          symbol: this.cmdLineArgs.symbol as string,
+          conId: (this.cmdLineArgs.conid as number) ?? undefined,
+          secType: this.cmdLineArgs.sectype as SecType,
+          exchange: this.cmdLineArgs.exchange as string,
+          currency: this.cmdLineArgs.currency as string,
+          lastTradeDateOrContractMonth: this.cmdLineArgs.expiry as string,
+          strike: (this.cmdLineArgs.strike as number) ?? undefined,
+          right: this.cmdLineArgs.right as OptionType,
+        },
+        "TRADES",
+        true,
+        1
+      )
+      .then((timestamp) => {
+        this.printText(timestamp);
+        this.exit();
+      })
+      .catch((err: IBApiNextError) => {
+        this.error(`getHeadTimestamp failed with '${err.error.message}'`);
+      });
+  }
+}
+
+// run the app
+
+new PrintHeadTimestampApp().start();


### PR DESCRIPTION
Fixes:

- fix reqHeadTimestamp function / encoder.

New functions:

`- IBApiNext.getHeadTimestamp(): Promise<number>`

New tools:

- get-head-timestamp.js

New tests (RxJS wrappers only):

get-head-timestamp.test.ts