### PR TITLE
IBApiNext: add support for getting histogram data

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -320,5 +320,29 @@
         "!**/node_modules/**"
       ]
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tool: histogram-data",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "runtimeArgs": [
+        "--trace-warnings"
+      ],
+      "program": "${workspaceFolder}/dist/tools/histogram-data.js",
+      "args": [
+        "-conid=3691937",
+        "-exchange=SMART",
+        "-period=3",
+        "-periodUnit=DAY",
+        "-port=4002"
+      ],
+      "outputCapture": "std",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
   ]
 }

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -5,8 +5,10 @@ import {
   Contract,
   ContractDetails,
   DepthMktDataDescription,
+  DurationUnit,
   ErrorCode,
   EventName,
+  HistogramEntry,
   HistoricalTick,
   HistoricalTickBidAsk,
   HistoricalTickLast,
@@ -1599,6 +1601,61 @@ export class IBApiNext {
           "reqMktDepthExchanges" // use same instance id each time, to make sure there is only 1 pending request at time
         )
         .pipe(map((v: { all: DepthMktDataDescription[] }) => v.all))
+    );
+  }
+
+  /** mktDepthExchanges event handler */
+  private readonly onHistogramData = (
+    subscriptions: Map<number, IBApiNextSubscription<HistogramEntry[]>>,
+    reqId: number,
+    data: HistogramEntry[]
+  ): void => {
+    // get the subscription
+
+    const sub = subscriptions.get(reqId);
+    if (!sub) {
+      return;
+    }
+
+    // deliver data
+
+    sub.next({ all: data });
+    sub.complete();
+  };
+
+  /**
+   * Get data histogram of specified contract.
+   *
+   * @param contract [[Contract]] object for which histogram is being requested
+   * @param useRTH Use regular trading hours only, `true` for yes or `false` for no.
+   * @param duration Period duration of which data is being requested
+   * @param durationUnit Duration unit of which data is being requested
+   */
+  getHistogramData(
+    contract: Contract,
+    useRTH: boolean,
+    duration: number,
+    durationUnit: DurationUnit
+  ): Promise<HistogramEntry[]> {
+    return lastValueFrom(
+      this.subscriptions
+        .register<HistogramEntry[]>(
+          (reqId) => {
+            this.api.reqHistogramData(
+              reqId,
+              contract,
+              useRTH,
+              duration,
+              durationUnit
+            );
+          },
+          (reqId) => {
+            this.api.cancelHistogramData(reqId);
+          },
+          [[EventName.histogramData, this.onHistogramData]],
+          `${JSON.stringify(contract)}:${useRTH}:${duration}:${durationUnit}`
+        )
+        .pipe(map((v: { all: HistogramEntry[] }) => v.all))
     );
   }
 }

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1611,14 +1611,12 @@ export class IBApiNext {
     data: HistogramEntry[]
   ): void => {
     // get the subscription
-
     const sub = subscriptions.get(reqId);
     if (!sub) {
       return;
     }
-
+    
     // deliver data
-
     sub.next({ all: data });
     sub.complete();
   };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "eventemitter3";
+import { DurationUnit } from "..";
 
 import { ErrorCode } from "../common/errorCode";
 import { Controller } from "../core/io/controller";
@@ -812,20 +813,24 @@ export class IBApi extends EventEmitter {
    * @param tickerId An identifier for the request.
    * @param contract [[Contract]] object for which histogram is being requested
    * @param useRTH Use regular trading hours only, `true` for yes or `false` for no.
-   * @param period Period of which data is being requested, e.g. "3 days"
+   * @param period Period of which data is being requested
+   * @param periodUnit Unit of the period of which data is being requested
    */
   reqHistogramData(
     tickerId: number,
     contract: Contract,
     useRTH: boolean,
-    period: string
+    period: number,
+    periodUnit: DurationUnit
   ): IBApi {
+    const periodStr =
+      period + " " + periodUnit.toString().toLowerCase() + "s";
     this.controller.schedule(() =>
       this.controller.encoder.reqHistogramData(
         tickerId,
         contract,
         useRTH,
-        period
+        periodStr
       )
     );
     return this;

--- a/src/api/data/enum/duration-unit.ts
+++ b/src/api/data/enum/duration-unit.ts
@@ -1,0 +1,12 @@
+/**
+ * Duration unit.
+ */
+export enum DurationUnit {
+  SECOND = "SECOND",
+  DAY = "DAY",
+  WEEK = "WEEK",
+  MONTH = "MONTH",
+  YEAR = "YEAR",
+}
+
+export default DurationUnit;

--- a/src/core/io/encoder.ts
+++ b/src/core/io/encoder.ts
@@ -2914,8 +2914,8 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
       OUT_MSG_ID.REQ_HISTOGRAM_DATA,
       tickerId,
       this.encodeContract(contract),
-      useRTH,
-      timePeriod
+      timePeriod,
+      useRTH ? 1 : 0
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export { HistogramEntry } from "./api/historical/histogramEntry";
 export { HistoricalTick } from "./api/historical/historicalTick";
 export { HistoricalTickBidAsk } from "./api/historical/historicalTickBidAsk";
 export { HistoricalTickLast } from "./api/historical/historicalTickLast";
+export { DurationUnit } from "./api/data/enum/duration-unit";
 
 // export realtime market-data types
 

--- a/src/tests/unit/api-next/get-histogram-data.test.ts
+++ b/src/tests/unit/api-next/get-histogram-data.test.ts
@@ -1,0 +1,40 @@
+/**
+ * This file implements tests for the [[IBApiNext.getHistogramData]] function.
+ */
+
+import { IBApi, IBApiNext, IBApiNextError, EventName } from "../../..";
+import DurationUnit from "../../../api/data/enum/duration-unit";
+import HistogramEntry from "../../../api/historical/histogramEntry";
+
+describe("RxJS Wrapper: getHistogramData()", () => {
+  test("Promise result", (done) => {
+    // create IBApiNext
+
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    // emit a EventName.histogramData and verify RxJS result
+
+    const refData: HistogramEntry[] = [
+      { price: 1, size: 2 },
+      { price: 11, size: 12 },
+      { price: 21, size: 22 },
+    ];
+
+    apiNext
+      .getHistogramData({}, true, 1, DurationUnit.DAY)
+      .then((data) => {
+        expect(data.length).toEqual(refData.length);
+        refData.forEach((r, i) => {
+          expect(r.price).toEqual(refData[i].price);
+          expect(r.size).toEqual(refData[i].size);
+        });
+        done();
+      })
+      .catch((error: IBApiNextError) => {
+        fail(error.error.message);
+      });
+
+    api.emit(EventName.histogramData, 1, refData);
+  });
+});

--- a/src/tools/histogram-data.ts
+++ b/src/tools/histogram-data.ts
@@ -1,0 +1,90 @@
+/**
+ * This App will print histogram data of a contract.
+ */
+import path from "path";
+
+import { IBApiNextError } from "../api-next";
+import DurationUnit from "../api/data/enum/duration-unit";
+import logger from "../common/logger";
+import { IBApiNextApp } from "./common/ib-api-next-app";
+
+/////////////////////////////////////////////////////////////////////////////////
+// The help text                                                               //
+/////////////////////////////////////////////////////////////////////////////////
+
+const DESCRIPTION_TEXT = "Print histogram data of a contract.";
+const USAGE_TEXT = "Usage: histogram-data.js <options>";
+const OPTION_ARGUMENTS: [string, string][] = [
+  [
+    "conid=<number>",
+    "(required) Contract ID (conId) of contract to receive histogram data for.",
+  ],
+  ["exchange=<name>", "The destination exchange name."],
+  ["period=<seconds>", "(required) Period of which data is being requested"],
+  [
+    "periodUnit=<SECOND|DAY|WEEK|MONTH|YEAR>",
+    "(required) Unit of the period argument",
+  ],
+];
+const EXAMPLE_TEXT =
+  "histogram-data.js -conid=3691937 -exchange=SMART -period=3 -periodUnit=DAY";
+
+//////////////////////////////////////////////////////////////////////////////
+// The App code                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+class PrintHistogramDataApp extends IBApiNextApp {
+  constructor() {
+    super(DESCRIPTION_TEXT, USAGE_TEXT, OPTION_ARGUMENTS, EXAMPLE_TEXT);
+  }
+
+  /**
+   * Start the the app.
+   */
+  start(): void {
+    const scriptName = path.basename(__filename);
+    logger.debug(`Starting ${scriptName} script`);
+
+    if (!this.cmdLineArgs.conid) {
+      this.error("-conid argument missing.");
+    }
+    if (!this.cmdLineArgs.exchange) {
+      this.error("-exchange argument missing.");
+    }
+    if (!this.cmdLineArgs.period) {
+      this.error("-period argument missing.");
+    }
+    if (!this.cmdLineArgs.periodUnit) {
+      this.error("-periodUnit argument missing.");
+    }
+    if (!(this.cmdLineArgs.periodUnit in DurationUnit)) {
+      this.error(
+        "Invalid -periodUnit argument value: " + this.cmdLineArgs.periodUnit
+      );
+    }
+
+    this.connect();
+
+    this.api
+      .getHistogramData(
+        {
+          conId: this.cmdLineArgs.conid as number,
+          exchange: this.cmdLineArgs.exchange as string,
+        },
+        false,
+        this.cmdLineArgs.period as number,
+        this.cmdLineArgs.periodUnit as DurationUnit
+      )
+      .then((data) => {
+        this.printObject(data);
+        this.exit();
+      })
+      .catch((err: IBApiNextError) => {
+        this.error(`getHistogramData failed with '${err.error.message}'`);
+      });
+  }
+}
+
+// run the app
+
+new PrintHistogramDataApp().start();


### PR DESCRIPTION
New functions:

`- IBApiNext.getHistogramData(contract: Contract, useRTH: boolean, duration: number, durationUnit: DurationUnit): Promise<HistogramEntry[]>`

New types / enums:

- DurationUnit

New tools:

- histogram-data.js

New tests (RxJS wrappers only):

get-histogram-data.test.ts