### PR TITLE
Replace Number.MAX_VALUE with undefined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ or
 
 ## Update from 1.1.x to 1.2.x
 
-If you currently use version 1.1.x and want to upgrade to 1.2.x please note that there is breaking change that might affect your code:
+If you currently use version 1.1.x and want to upgrade to 1.2.x please note that there is a breaking change that might affect your code:
 
-Versions up to 1.1.x did use `Number.MAX_VALUE` for values that are not available. This was to b in-sync with the official TWS API Java interfaces. Since the usage of `Number.MAX_VALUE` is very uncommon in JScript/TS, all versions starting from 1.2.1 will return `undefined` instead.
+Versions up to 1.1.x did return `Number.MAX_VALUE` on values that are not available. This was to be in-sync with the official TWS API Java interfaces. Since the usage of `Number.MAX_VALUE` is very uncommon in JScript/TS and caused / causes lot of confusion, all versions starting from 1.2.1 will return `undefined` instead.
 
-If you have checked for `Number.MAX_VALUE` up to now, you can drop it. If you have not checked for `undefined` yet, you should add it.
+If you have checked for `Number.MAX_VALUE` up to now, you can drop this check. If you have not checked for `undefined` yet, you should add it.
 
 ## API Documenation
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,38 @@ Versions up to 1.1.x did return `Number.MAX_VALUE` on values that are not availa
 
 If you have checked for `Number.MAX_VALUE` up to now, you can drop this check. If you have not checked for `undefined` yet, you should add it.
 
+Example:
+
+```js
+ib.on(EventName.pnlSingle, (
+      reqId: number,
+      pos: number,
+      dailyPnL: number,
+      unrealizedPnL: number,
+      realizedPnL: number,
+      value: number
+    ) => {
+      ...
+    }
+  );
+```
+
+now is (look at `unrealizedPnL` and `realizedPnL`)
+
+```js
+ib.on(EventName.pnlSingle, (
+      reqId: number,
+      pos: number,
+      dailyPnL: number,
+      unrealizedPnL: number | undefined,
+      realizedPnL: number | undefined,
+      value: number
+    ) => {
+      ...
+    }
+  );
+```
+
 ## API Documenation
 
 <b>[See API documentation here.](https://stoqey.github.io/ib-doc/)</b>

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ ib.on(EventName.error, (err: Error, code: ErrorCode, reqId: number) => {
 })
   .on(
     EventName.position,
-    (account: string, contract: Contract, pos: number, avgCost: number) => {
+    (account: string, contract: Contract, pos: number, avgCost?: number) => {
       console.log(`${account}: ${pos} x ${contract.symbol} @ ${avgCost}`);
       positionsCount++;
     }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ or
 
     $ yarn add @stoqey/ib
 
+## Update from 1.1.x to 1.2.x
+
+If you currently use version 1.1.x and want to upgrade to 1.2.x please note that there is breaking change that might affect your code:
+
+Versions up to 1.1.x did use `Number.MAX_VALUE` for values that are not available. This was to b in-sync with the official TWS API Java interfaces. Since the usage of `Number.MAX_VALUE` is very uncommon in JScript/TS, all versions starting from 1.2.1 will return `undefined` instead.
+
+If you have checked for `Number.MAX_VALUE` up to now, you can drop it. If you have not checked for `undefined` yet, you should add it.
+
 ## API Documenation
 
 <b>[See API documentation here.](https://stoqey.github.io/ib-doc/)</b>
@@ -49,10 +57,6 @@ IBApiNext still is in preview stage. Not all functions are available yet, and we
 | IB Gateway paper account |  4002 |
 | TWS Live Account         | 7496  |
 | TWS papertrading account | 7497  |
-
-## Important
-
-IBApi is returning `Number.MAX_SAFE_INTEGER` when there is no value from IB, commonly seen when there is no bid / offer or other missing market data.
 
 ## IBApi Examples
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stoqey/ib",
   "private": false,
-  "version": "1.1.59",
+  "version": "1.2.1",
   "description": "Interactive Brokers TWS/IB Gateway API client library for Node.js (TS)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -471,7 +471,7 @@ export class IBApiNext {
     account: string,
     contract: Contract,
     pos: number,
-    avgCost: number
+    avgCost?: number
   ): void => {
     const updatedPosition: Position = { account, contract, pos, avgCost };
 
@@ -611,8 +611,8 @@ export class IBApiNext {
     subscriptions: Map<number, IBApiNextSubscription<PnL>>,
     reqId: number,
     dailyPnL: number,
-    unrealizedPnL: number,
-    realizedPnL: number
+    unrealizedPnL?: number,
+    realizedPnL?: number
   ): void => {
     // get subscription
 
@@ -655,8 +655,8 @@ export class IBApiNext {
     reqId: number,
     pos: number,
     dailyPnL: number,
-    unrealizedPnL: number,
-    realizedPnL: number,
+    unrealizedPnL: number | undefined,
+    realizedPnL: number | undefined,
     value: number
   ) => {
     // get subscription
@@ -727,8 +727,8 @@ export class IBApiNext {
   private readonly onTick = (
     subscriptions: Map<number, IBApiNextSubscription<MutableMarketData>>,
     reqId: number,
-    tickType: IBApiTickType,
-    value: number
+    tickType?: IBApiTickType,
+    value?: number
   ): void => {
     // convert -1 on Bid/Ask to undefined
 
@@ -1176,7 +1176,7 @@ export class IBApiNext {
     low: number,
     close: number,
     volume: number,
-    count: number,
+    count: number | undefined,
     WAP: number
   ): void => {
     // get subscription

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -66,15 +66,6 @@ const LOG_TAG = "IBApiNext";
 const TWS_LOG_TAG = "TWS";
 
 /**
- * @internal
- *
- * Returns undefined is the value is Number.MAX_VALUE, or the value otherwise.
- */
-function undefineMax(v: number | undefined): number | undefined {
-  return v === undefined || v === Number.MAX_VALUE ? undefined : v;
-}
-
-/**
  * Input arguments on the [[IBApiNext]] constructor.
  */
 export interface IBApiNextCreationOptions {
@@ -680,10 +671,10 @@ export class IBApiNext {
     subscription.next({
       all: {
         position: pos,
-        dailyPnL: undefineMax(dailyPnL),
-        unrealizedPnL: undefineMax(unrealizedPnL),
-        realizedPnL: undefineMax(realizedPnL),
-        marketValue: undefineMax(value),
+        dailyPnL: dailyPnL,
+        unrealizedPnL: unrealizedPnL,
+        realizedPnL: realizedPnL,
+        marketValue: value,
       },
     });
   };
@@ -739,7 +730,7 @@ export class IBApiNext {
     tickType: IBApiTickType,
     value: number
   ): void => {
-    // filter -1 on Bid/Ask and Number.MAX_VALUE on all.
+    // convert -1 on Bid/Ask to undefined
 
     if (
       value === -1 &&
@@ -748,10 +739,7 @@ export class IBApiNext {
         tickType === IBApiTickType.ASK ||
         tickType === IBApiTickType.DELAYED_ASK)
     ) {
-      value = Number.MAX_VALUE;
-    }
-    if (value === Number.MAX_VALUE) {
-      return;
+      value = undefined;
     }
 
     // get subscription
@@ -1043,14 +1031,12 @@ export class IBApiNext {
     const changed = new MutableMarketData();
 
     ticks.forEach((tick) => {
-      if (tick[1].value !== Number.MAX_VALUE && tick[1].value !== undefined) {
-        if (cached.has(tick[0])) {
-          changed.set(tick[0], tick[1]);
-        } else {
-          added.set(tick[0], tick[1]);
-        }
-        cached.set(tick[0], tick[1]);
+      if (cached.has(tick[0])) {
+        changed.set(tick[0], tick[1]);
+      } else {
+        added.set(tick[0], tick[1]);
       }
+      cached.set(tick[0], tick[1]);
     });
 
     // deliver to subject
@@ -1669,7 +1655,7 @@ export class IBApiNext {
     if (!sub) {
       return;
     }
-    
+
     // deliver data
     sub.next({ all: data });
     sub.complete();

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -727,7 +727,7 @@ export class IBApiNext {
   private readonly onTick = (
     subscriptions: Map<number, IBApiNextSubscription<MutableMarketData>>,
     reqId: number,
-    tickType?: IBApiTickType,
+    tickType: IBApiTickType,
     value?: number
   ): void => {
     // convert -1 on Bid/Ask to undefined

--- a/src/api-next/market/market-data.ts
+++ b/src/api-next/market/market-data.ts
@@ -3,7 +3,7 @@ import { TickType, ItemListUpdate } from "../..";
 /**  A market data tick on [[IBApiNext]]. */
 export interface MarketDataTick {
   /** The tick value. */
-  readonly value: number;
+  readonly value?: number;
 
   /**
    * The ingress timestamp (UNIX) of the value.

--- a/src/api-next/position/position.ts
+++ b/src/api-next/position/position.ts
@@ -14,7 +14,7 @@ export interface Position {
   readonly pos: number;
 
   /** The average cost of the position. */
-  readonly avgCost: number;
+  readonly avgCost?: number;
 }
 
 /** Summary of all linked accounts, with account id as key. */

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -823,8 +823,7 @@ export class IBApi extends EventEmitter {
     period: number,
     periodUnit: DurationUnit
   ): IBApi {
-    const periodStr =
-      period + " " + periodUnit.toString().toLowerCase() + "s";
+    const periodStr = period + " " + periodUnit.toString().toLowerCase() + "s";
     this.controller.schedule(() =>
       this.controller.encoder.reqHistogramData(
         tickerId,
@@ -2002,7 +2001,7 @@ export declare interface IBApi {
    * Returns array of sample contract descriptions.
    *
    * @param listener
-   * familyCodes Array of family codes.
+   * contractDescriptions Array of contract descriptions.
    *
    * @see [[reqFamilyCodes]]
    */
@@ -2090,7 +2089,7 @@ export declare interface IBApi {
       low: number,
       close: number,
       volume: number,
-      count: number,
+      count: number | undefined,
       WAP: number,
       hasGaps: boolean | undefined
     ) => void
@@ -2410,12 +2409,12 @@ export declare interface IBApi {
       filled: number,
       remaining: number,
       avgFillPrice: number,
-      permId: number,
-      parentId: number,
-      lastFillPrice: number,
-      clientId: number,
-      whyHeld: string,
-      mktCapPrice: number
+      permId?: number,
+      parentId?: number,
+      lastFillPrice?: number,
+      clientId?: number,
+      whyHeld?: string,
+      mktCapPrice?: number
     ) => void
   ): this;
 
@@ -2438,8 +2437,8 @@ export declare interface IBApi {
     listener: (
       reqId: number,
       dailyPnL: number,
-      unrealizedPnL: number,
-      realizedPnL: number
+      unrealizedPnL?: number,
+      realizedPnL?: number
     ) => void
   ): this;
 
@@ -2465,8 +2464,8 @@ export declare interface IBApi {
       reqId: number,
       pos: number,
       dailyPnL: number,
-      unrealizedPnL: number,
-      realizedPnL: number,
+      unrealizedPnL: number | undefined,
+      realizedPnL: number | undefined,
       value: number
     ) => void
   ): this;
@@ -2491,7 +2490,7 @@ export declare interface IBApi {
       account: string,
       contract: Contract,
       pos: number,
-      avgCost: number
+      avgCost?: number
     ) => void
   ): this;
 
@@ -2671,7 +2670,7 @@ export declare interface IBApi {
       distance: string,
       benchmark: string,
       projection: string,
-      legsStr: string
+      legsStr?: string
     ) => void
   ): this;
 
@@ -2962,8 +2961,6 @@ export declare interface IBApi {
    *
    * impliedVolatility: The implied volatility calculated by the TWS option modeler, using the specified tick type value.
    *
-   * tickAttrib: 0 - return based, 1- price based.
-   *
    * delta: The option delta value.
    *
    * value: The tick value.
@@ -2987,15 +2984,14 @@ export declare interface IBApi {
     listener: (
       tickerId: number,
       field: TickType,
-      tickAttrib: number,
-      impliedVolatility: number,
-      delta: number,
-      optPrice: number,
-      pvDividend: number,
-      gamma: number,
-      vega: number,
-      theta: number,
-      undPrice: number
+      impliedVolatility?: number,
+      delta?: number,
+      optPrice?: number,
+      pvDividend?: number,
+      gamma?: number,
+      vega?: number,
+      theta?: number,
+      undPrice?: number
     ) => void
   ): this;
 
@@ -3024,7 +3020,7 @@ export declare interface IBApi {
       tickerId: number,
       field: TickType,
       value: number,
-      attribs: unknown /* TODO: replace with TickAttrib type as soon as available. */
+      attribs?: unknown /* TODO: replace with TickAttrib type as soon as available. */
     ) => void
   ): this;
 
@@ -3054,13 +3050,13 @@ export declare interface IBApi {
    *
    * field: The type of size being received (i.e. bid size)
    *
-   * size: The actual size. US stocks have a multiplier of 100.
+   * size: The actual size.
    *
    * @see [[reqMktData]]
    */
   on(
     event: EventName.tickSize,
-    listener: (tickerId: number, field: TickType, value: number) => void
+    listener: (tickerId: number, field?: TickType, value?: number) => void
   ): this;
 
   /**
@@ -3261,10 +3257,10 @@ export declare interface IBApi {
       position: number,
       marketPrice: number,
       marketValue: number,
-      averageCost: number,
-      unrealizedPNL: number,
-      realizedPNL: number,
-      accountName: string
+      averageCost?: number,
+      unrealizedPNL?: number,
+      realizedPNL?: number,
+      accountName?: string
     ) => void
   ): this;
 
@@ -3336,7 +3332,7 @@ export declare interface IBApi {
       side: number,
       price: number,
       size: number,
-      isSmartDepth: boolean
+      isSmartDepth?: boolean
     ) => void
   ): this;
 

--- a/src/api/data/container/soft-dollar-tier.ts
+++ b/src/api/data/container/soft-dollar-tier.ts
@@ -9,7 +9,7 @@ export interface SoftDollarTier {
   value?: string;
 
   /** The display name of the Soft Dollar Tier. */
-  displayName: string;
+  displayName?: string;
 }
 
 export default SoftDollarTier;

--- a/src/api/order/orderComboLeg.ts
+++ b/src/api/order/orderComboLeg.ts
@@ -3,7 +3,7 @@
  */
 export interface OrderComboLeg {
   /**	The order's leg's price. */
-  price: number;
+  price?: number;
 }
 
 export default OrderComboLeg;

--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -430,7 +430,7 @@ export class Decoder {
    */
   readDouble(): number | undefined {
     const token = this.readStr();
-    if (token === null || token === "") {
+    if (!token || token === "") {
       return 0;
     }
     const val = parseFloat(token);
@@ -444,7 +444,7 @@ export class Decoder {
    */
   readDoubleOrUndefined(): number | undefined {
     const token = this.readStr();
-    if (token === null || token === "") {
+    if (!token || token === "") {
       return undefined;
     }
     const val = parseFloat(token);
@@ -459,7 +459,7 @@ export class Decoder {
    */
   readInt(): number | undefined {
     const token = this.readStr();
-    if (token === null || token === "") {
+    if (!token || token === "") {
       return 0;
     }
     const val = parseInt(token, 10);
@@ -473,7 +473,7 @@ export class Decoder {
    */
   readIntOrUndefined(): number | undefined {
     const token = this.readStr();
-    if (token === null || token === "") {
+    if (!token || token === "") {
       return undefined;
     }
     const val = parseInt(token, 10);

--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -436,14 +436,13 @@ export class Decoder {
   }
 
   /**
-   * Read a token from queue and return it as floating point value.
-   *
-   * Returns Number.MAX_VALUE if the token is empty.
+   * Read a token from queue and return it as floating point value,
+   * or undefined if the token is empty.
    */
-  readDoubleMax(): number {
+  readDoubleOrUndefined(): number | undefined {
     const token = this.readStr();
     if (token === null || token === "") {
-      return Number.MAX_VALUE;
+      return undefined;
     }
     return parseFloat(token);
   }
@@ -463,13 +462,12 @@ export class Decoder {
 
   /**
    * Read a token from queue and return it as integer value.
-   *
-   * Returns Number.MAX_VALUE if the token is empty.
+   * or undefined if the token is empty.
    */
-  readIntMax(): number {
+  readIntOrUndefined(): number | undefined {
     const token = this.readStr();
     if (token === null || token === "") {
-      return Number.MAX_VALUE;
+      return undefined;
     }
     return parseInt(token, 10);
   }
@@ -570,7 +568,7 @@ export class Decoder {
   private decodeMsg_ORDER_STATUS(): void {
     const version =
       this.serverVersion >= MIN_SERVER_VER.MARKET_CAP_PRICE
-        ? Number.MAX_VALUE
+        ? Number.MAX_SAFE_INTEGER
         : this.readInt();
     const id = this.readInt();
     const status = this.readStr();
@@ -603,7 +601,7 @@ export class Decoder {
       whyHeld = this.readStr();
     }
 
-    let mktCapPrice = Number.MAX_VALUE;
+    let mktCapPrice: number | undefined = undefined;
     if (this.serverVersion >= MIN_SERVER_VER.MARKET_CAP_PRICE) {
       mktCapPrice = this.readDouble();
     }
@@ -794,9 +792,9 @@ export class Decoder {
 
     const marketPrice = this.readDouble();
     const marketValue = this.readDouble();
-    let averageCost = Number.MAX_VALUE;
-    let unrealizedPNL = Number.MAX_VALUE;
-    let realizedPNL = Number.MAX_VALUE;
+    let averageCost: number | undefined = undefined;
+    let unrealizedPNL: number | undefined = undefined;
+    let realizedPNL: number | undefined = undefined;
     if (version >= 3) {
       averageCost = this.readDouble();
       unrealizedPNL = this.readDouble();
@@ -1128,7 +1126,7 @@ export class Decoder {
    * Decode a HISTORICAL_DATA message from data queue and emit historicalData events.
    */
   private decodeMsg_HISTORICAL_DATA(): void {
-    let version = Number.MAX_VALUE;
+    let version = Number.MAX_SAFE_INTEGER;
     if (this.serverVersion < MIN_SERVER_VER.SYNT_REALTIME_BARS) {
       version = this.readInt();
     }
@@ -1417,21 +1415,21 @@ export class Decoder {
     let impliedVol = this.readDouble();
     if (impliedVol == -1) {
       // -1 is the "not yet computed" indicator
-      impliedVol = Number.MAX_VALUE;
+      impliedVol = undefined;
     }
 
     let delta = this.readDouble();
     if (delta == -2) {
       // -2 is the "not yet computed" indicator
-      delta = Number.MAX_VALUE;
+      delta = undefined;
     }
 
-    let optPrice = Number.MAX_VALUE;
-    let pvDividend = Number.MAX_VALUE;
-    let gamma = Number.MAX_VALUE;
-    let vega = Number.MAX_VALUE;
-    let theta = Number.MAX_VALUE;
-    let undPrice = Number.MAX_VALUE;
+    let optPrice: number | undefined = undefined;
+    let pvDividend: number | undefined = undefined;
+    let gamma: number | undefined = undefined;
+    let vega: number | undefined = undefined;
+    let theta: number | undefined = undefined;
+    let undPrice: number | undefined = undefined;
 
     if (
       version >= 6 ||
@@ -1441,13 +1439,13 @@ export class Decoder {
       optPrice = this.readDouble();
       if (optPrice == -1) {
         // -1 is the "not yet computed" indicator
-        optPrice = Number.MAX_VALUE;
+        optPrice = undefined;
       }
 
       pvDividend = this.readDouble();
       if (pvDividend == -1) {
         // -1 is the "not yet computed" indicator
-        pvDividend = Number.MAX_VALUE;
+        pvDividend = undefined;
       }
     }
 
@@ -1455,25 +1453,25 @@ export class Decoder {
       gamma = this.readDouble();
       if (gamma == -2) {
         // -2 is the "not yet computed" indicator
-        gamma = Number.MAX_VALUE;
+        gamma = undefined;
       }
 
       vega = this.readDouble();
       if (vega == -2) {
         // -2 is the "not yet computed" indicator
-        vega = Number.MAX_VALUE;
+        vega = undefined;
       }
 
       theta = this.readDouble();
       if (theta == -2) {
         // -2 is the "not yet computed" indicator
-        theta = Number.MAX_VALUE;
+        theta = undefined;
       }
 
       undPrice = this.readDouble();
       if (undPrice == -1) {
         // -1 is the "not yet computed" indicator
-        undPrice = Number.MAX_VALUE;
+        undPrice = undefined;
       }
     }
 
@@ -1983,7 +1981,7 @@ export class Decoder {
           secType: this.readStr() as SecType,
           listingExch: this.readStr(),
           serviceDataType: this.readStr(),
-          aggGroup: this.readInt() || Number.MAX_VALUE,
+          aggGroup: this.readIntOrUndefined(),
         };
       } else {
         depthMktDataDescriptions[i] = {
@@ -1991,7 +1989,7 @@ export class Decoder {
           secType: this.readStr() as SecType,
           listingExch: "",
           serviceDataType: this.readBool() ? "Deep2" : "Deep",
-          aggGroup: Number.MAX_VALUE,
+          aggGroup: undefined,
         };
       }
     }
@@ -2145,8 +2143,8 @@ export class Decoder {
     const reqId = this.readInt();
     const dailyPnL = this.readDouble();
 
-    let unrealizedPnL = Number.MAX_VALUE;
-    let realizedPnL = Number.MAX_VALUE;
+    let unrealizedPnL: number | undefined = undefined;
+    let realizedPnL: number | undefined = undefined;
 
     if (this.serverVersion >= MIN_SERVER_VER.UNREALIZED_PNL) {
       unrealizedPnL = this.readDouble();
@@ -2166,8 +2164,8 @@ export class Decoder {
     const pos = this.readInt();
     const dailyPnL = this.readDouble();
 
-    let unrealizedPnL = Number.MAX_VALUE;
-    let realizedPnL = Number.MAX_VALUE;
+    let unrealizedPnL: number | undefined = undefined;
+    let realizedPnL: number | undefined = undefined;
 
     if (this.serverVersion >= MIN_SERVER_VER.UNREALIZED_PNL) {
       unrealizedPnL = this.readDouble();
@@ -2389,12 +2387,12 @@ export class Decoder {
     if (this.serverVersion < 29) {
       order.lmtPrice = this.readDouble();
     } else {
-      order.lmtPrice = this.readDoubleMax();
+      order.lmtPrice = this.readDoubleOrUndefined();
     }
     if (this.serverVersion < 30) {
       order.auxPrice = this.readDouble();
     } else {
-      order.auxPrice = this.readDoubleMax();
+      order.auxPrice = this.readDoubleOrUndefined();
     }
     order.tif = this.readStr();
     order.ocaGroup = this.readStr();
@@ -2438,7 +2436,7 @@ export class Decoder {
 
     if (this.serverVersion >= 9) {
       order.rule80A = this.readStr();
-      order.percentOffset = this.readDoubleMax();
+      order.percentOffset = this.readDoubleOrUndefined();
       order.settlingFirm = this.readStr();
 
       order.shortSaleSlot = this.readInt();
@@ -2449,31 +2447,31 @@ export class Decoder {
         order.exemptCode = this.readInt();
       }
 
-      order.startingPrice = this.readDoubleMax();
-      order.stockRefPrice = this.readDoubleMax();
-      order.delta = this.readDoubleMax();
+      order.startingPrice = this.readDoubleOrUndefined();
+      order.stockRefPrice = this.readDoubleOrUndefined();
+      order.delta = this.readDoubleOrUndefined();
 
-      order.stockRangeLower = this.readDoubleMax();
-      order.stockRangeUpper = this.readDoubleMax();
+      order.stockRangeLower = this.readDoubleOrUndefined();
+      order.stockRangeUpper = this.readDoubleOrUndefined();
 
       order.displaySize = this.readInt();
 
       order.sweepToFill = this.readBool();
       order.allOrNone = this.readBool();
-      order.minQty = this.readIntMax();
+      order.minQty = this.readIntOrUndefined();
       order.ocaType = this.readInt();
     }
 
     order.triggerMethod = this.serverVersion >= 10 ? this.readInt() : undefined;
 
     if (this.serverVersion >= 11) {
-      order.volatility = this.readDoubleMax();
+      order.volatility = this.readDoubleOrUndefined();
       order.volatilityType = this.readInt();
       if (this.serverVersion == 11) {
         order.deltaNeutralOrderType = this.readInt() == 0 ? "NONE" : "MKT";
       } else {
         order.deltaNeutralOrderType = this.readStr();
-        order.deltaNeutralAuxPrice = this.readDoubleMax();
+        order.deltaNeutralAuxPrice = this.readDoubleOrUndefined();
 
         if (this.serverVersion >= 27 && order.deltaNeutralOrderType !== "") {
           order.deltaNeutralConId = this.readInt();
@@ -2494,11 +2492,11 @@ export class Decoder {
     }
 
     if (this.serverVersion >= 13) {
-      order.trailStopPrice = this.readDoubleMax();
+      order.trailStopPrice = this.readDoubleOrUndefined();
     }
 
     if (this.serverVersion >= 30) {
-      order.trailStopPrice = this.readDoubleMax();
+      order.trailStopPrice = this.readDoubleOrUndefined();
     }
 
     if (this.serverVersion >= 1) {
@@ -2526,7 +2524,7 @@ export class Decoder {
       const orderComboLegsCount = this.readInt();
       const orderComboLegs = new Array(orderComboLegsCount);
       for (let i = 0; i < orderComboLegsCount; i++) {
-        orderComboLegs[i] = { price: this.readDoubleMax() };
+        orderComboLegs[i] = { price: this.readDoubleOrUndefined() };
       }
       order.orderComboLegs = orderComboLegs;
     }
@@ -2546,26 +2544,22 @@ export class Decoder {
 
     if (this.serverVersion >= 15) {
       if (this.serverVersion >= 20) {
-        order.scaleInitLevelSize = this.readIntMax();
-        order.scaleSubsLevelSize = this.readIntMax();
+        order.scaleInitLevelSize = this.readIntOrUndefined();
+        order.scaleSubsLevelSize = this.readIntOrUndefined();
       } else {
-        /* notSuppScaleNumComponents = */ this.readIntMax();
-        order.scaleSubsLevelSize = this.readIntMax();
+        /* notSuppScaleNumComponents = */ this.readIntOrUndefined();
+        order.scaleSubsLevelSize = this.readIntOrUndefined();
       }
-      order.scalePriceIncrement = this.readDoubleMax();
+      order.scalePriceIncrement = this.readDoubleOrUndefined();
     }
 
-    if (
-      this.serverVersion >= 28 &&
-      order.scalePriceIncrement != undefined &&
-      order.scalePriceIncrement !== Number.MAX_VALUE
-    ) {
-      order.scalePriceAdjustValue = this.readDoubleMax();
-      order.scalePriceAdjustInterval = this.readIntMax();
-      order.scaleProfitOffset = this.readDoubleMax();
+    if (this.serverVersion >= 28 && order.scalePriceIncrement != undefined) {
+      order.scalePriceAdjustValue = this.readDoubleOrUndefined();
+      order.scalePriceAdjustInterval = this.readIntOrUndefined();
+      order.scaleProfitOffset = this.readDoubleOrUndefined();
       order.scaleAutoReset = this.readBool();
-      order.scaleInitPosition = this.readIntMax();
-      order.scaleInitFillQty = this.readIntMax();
+      order.scaleInitPosition = this.readIntOrUndefined();
+      order.scaleInitFillQty = this.readIntOrUndefined();
       order.scaleRandomPercent = this.readBool();
     }
 
@@ -2741,11 +2735,11 @@ export class Decoder {
       }
     }
 
-    order.trailStopPrice = this.readDoubleMax();
-    order.lmtPriceOffset = this.readDoubleMax();
+    order.trailStopPrice = this.readDoubleOrUndefined();
+    order.lmtPriceOffset = this.readDoubleOrUndefined();
 
     if (this.serverVersion >= MIN_SERVER_VER.CASH_QTY) {
-      order.cashQty = this.readDoubleMax();
+      order.cashQty = this.readDoubleOrUndefined();
     }
 
     if (this.serverVersion >= MIN_SERVER_VER.AUTO_PRICE_FOR_HEDGE) {
@@ -2757,7 +2751,7 @@ export class Decoder {
     }
 
     order.autoCancelDate = this.readStr();
-    order.filledQuantity = this.readDoubleMax();
+    order.filledQuantity = this.readDoubleOrUndefined();
     order.refFuturesConId = this.readInt();
     order.autoCancelParent = this.readBool();
     order.shareholder = this.readStr();
@@ -2824,13 +2818,13 @@ export class Decoder {
     if (version < 29) {
       order.lmtPrice = this.readDouble();
     } else {
-      order.lmtPrice = this.readDouble() || Number.MAX_VALUE;
+      order.lmtPrice = this.readDoubleOrUndefined();
     }
 
     if (version < 30) {
       order.auxPrice = this.readDouble();
     } else {
-      order.auxPrice = this.readDouble() || Number.MAX_VALUE;
+      order.auxPrice = this.readDoubleOrUndefined();
     }
 
     order.tif = this.readStr();
@@ -2855,7 +2849,7 @@ export class Decoder {
     }
     order.goodTillDate = this.readStr();
     order.rule80A = this.readStr();
-    order.percentOffset = this.readDouble() || Number.MAX_VALUE;
+    order.percentOffset = this.readDoubleOrUndefined();
     order.settlingFirm = this.readStr();
     order.shortSaleSlot = this.readInt();
     order.designatedLocation = this.readStr();
@@ -2867,26 +2861,26 @@ export class Decoder {
     }
 
     order.auctionStrategy = this.readInt();
-    order.startingPrice = this.readDouble() || Number.MAX_VALUE;
-    order.stockRefPrice = this.readDouble() || Number.MAX_VALUE;
-    order.delta = this.readDouble() || Number.MAX_VALUE;
-    order.stockRangeLower = this.readDouble() || Number.MAX_VALUE;
-    order.stockRangeUpper = this.readDouble() || Number.MAX_VALUE;
+    order.startingPrice = this.readDoubleOrUndefined();
+    order.stockRefPrice = this.readDoubleOrUndefined();
+    order.delta = this.readDoubleOrUndefined();
+    order.stockRangeLower = this.readDoubleOrUndefined();
+    order.stockRangeUpper = this.readDoubleOrUndefined();
     order.displaySize = this.readInt();
     order.blockOrder = this.readBool();
     order.sweepToFill = this.readBool();
     order.allOrNone = this.readBool();
-    order.minQty = this.readInt() || Number.MAX_VALUE;
+    order.minQty = this.readIntOrUndefined();
     order.ocaType = this.readInt();
     order.eTradeOnly = this.readBool();
     order.firmQuoteOnly = this.readBool();
-    order.nbboPriceCap = this.readDouble() || Number.MAX_VALUE;
+    order.nbboPriceCap = this.readDoubleOrUndefined();
     order.parentId = this.readInt();
     order.triggerMethod = this.readInt();
-    order.volatility = this.readDouble() || Number.MAX_VALUE;
+    order.volatility = this.readDoubleOrUndefined();
     order.volatilityType = this.readInt();
     order.deltaNeutralOrderType = this.readStr();
-    order.deltaNeutralAuxPrice = this.readDouble() || Number.MAX_VALUE;
+    order.deltaNeutralAuxPrice = this.readDoubleOrUndefined();
 
     if (version >= 27 && order?.deltaNeutralOrderType.length) {
       order.deltaNeutralConId = this.readInt();
@@ -2904,14 +2898,14 @@ export class Decoder {
 
     order.continuousUpdate = this.readInt();
     order.referencePriceType = this.readInt();
-    order.trailStopPrice = this.readDouble() || Number.MAX_VALUE;
+    order.trailStopPrice = this.readDoubleOrUndefined();
 
     if (version >= 30) {
-      order.trailingPercent = this.readDouble() || Number.MAX_VALUE;
+      order.trailingPercent = this.readDoubleOrUndefined();
     }
 
-    order.basisPoints = this.readDouble() || Number.MAX_VALUE;
-    order.basisPointsType = this.readInt() || Number.MAX_VALUE;
+    order.basisPoints = this.readDoubleOrUndefined();
+    order.basisPointsType = this.readIntOrUndefined();
 
     return order;
   }
@@ -3024,7 +3018,7 @@ class OrderDecoder {
     if (this.version < 29) {
       this.order.lmtPrice = this.decoder.readDouble();
     } else {
-      this.order.lmtPrice = this.decoder.readDoubleMax();
+      this.order.lmtPrice = this.decoder.readDoubleOrUndefined();
     }
   }
 
@@ -3032,7 +3026,7 @@ class OrderDecoder {
     if (this.version < 30) {
       this.order.auxPrice = this.decoder.readDouble();
     } else {
-      this.order.auxPrice = this.decoder.readDoubleMax();
+      this.order.auxPrice = this.decoder.readDoubleOrUndefined();
     }
   }
 
@@ -3137,7 +3131,7 @@ class OrderDecoder {
 
   readPercentOffset() {
     if (this.version >= 9) {
-      this.order.percentOffset = this.decoder.readDoubleMax();
+      this.order.percentOffset = this.decoder.readDoubleOrUndefined();
     }
   }
 
@@ -3167,16 +3161,16 @@ class OrderDecoder {
 
   readBoxOrderParams(): void {
     if (this.version >= 9) {
-      this.order.startingPrice = this.decoder.readDoubleMax();
-      this.order.stockRefPrice = this.decoder.readDoubleMax();
-      this.order.delta = this.decoder.readDoubleMax();
+      this.order.startingPrice = this.decoder.readDoubleOrUndefined();
+      this.order.stockRefPrice = this.decoder.readDoubleOrUndefined();
+      this.order.delta = this.decoder.readDoubleOrUndefined();
     }
   }
 
   readPegToStkOrVolOrderParams(): void {
     if (this.version >= 9) {
-      this.order.stockRangeLower = this.decoder.readDoubleMax();
-      this.order.stockRangeUpper = this.decoder.readDoubleMax();
+      this.order.stockRangeLower = this.decoder.readDoubleOrUndefined();
+      this.order.stockRangeUpper = this.decoder.readDoubleOrUndefined();
     }
   }
 
@@ -3215,7 +3209,7 @@ class OrderDecoder {
 
   readMinQty(): void {
     if (this.version >= 9) {
-      this.order.minQty = this.decoder.readIntMax();
+      this.order.minQty = this.decoder.readIntOrUndefined();
     }
   }
 
@@ -3239,7 +3233,7 @@ class OrderDecoder {
 
   readNbboPriceCap(): void {
     if (this.version >= 9) {
-      this.order.nbboPriceCap = this.decoder.readDoubleMax();
+      this.order.nbboPriceCap = this.decoder.readDoubleOrUndefined();
     }
   }
 
@@ -3257,14 +3251,14 @@ class OrderDecoder {
 
   readVolOrderParams(readOpenOrderAttribs: boolean): void {
     if (this.version >= 11) {
-      this.order.volatility = this.decoder.readDoubleMax();
+      this.order.volatility = this.decoder.readDoubleOrUndefined();
       this.order.volatilityType = this.decoder.readInt();
       if (this.version == 11) {
         const receivedInt = this.decoder.readInt();
         this.order.deltaNeutralOrderType = receivedInt == 0 ? "NONE" : "MKT";
       } else {
         this.order.deltaNeutralOrderType = this.decoder.readStr();
-        this.order.deltaNeutralAuxPrice = this.decoder.readDoubleMax();
+        this.order.deltaNeutralAuxPrice = this.decoder.readDoubleOrUndefined();
 
         if (
           this.version >= 27 &&
@@ -3303,18 +3297,18 @@ class OrderDecoder {
 
   readTrailParams(): void {
     if (this.version >= 13) {
-      this.order.trailStopPrice = this.decoder.readDoubleMax();
+      this.order.trailStopPrice = this.decoder.readDoubleOrUndefined();
     }
 
     if (this.version >= 30) {
-      this.order.trailingPercent = this.decoder.readDoubleMax();
+      this.order.trailingPercent = this.decoder.readDoubleOrUndefined();
     }
   }
 
   readBasisPoints(): void {
     if (this.version >= 14) {
-      this.order.basisPoints = this.decoder.readDoubleMax();
-      this.order.basisPointsType = this.decoder.readIntMax();
+      this.order.basisPoints = this.decoder.readDoubleOrUndefined();
+      this.order.basisPointsType = this.decoder.readIntOrUndefined();
     }
   }
 
@@ -3353,7 +3347,7 @@ class OrderDecoder {
         if (orderComboLegsCount > 0) {
           this.order.orderComboLegs = [];
           for (let i = 0; i < orderComboLegsCount; ++i) {
-            const price = this.decoder.readDoubleMax();
+            const price = this.decoder.readDoubleOrUndefined();
 
             this.order.orderComboLegs.push({
               price,
@@ -3384,26 +3378,22 @@ class OrderDecoder {
   readScaleOrderParams(): void {
     if (this.version >= 15) {
       if (this.version >= 20) {
-        this.order.scaleInitLevelSize = this.decoder.readIntMax();
-        this.order.scaleSubsLevelSize = this.decoder.readIntMax();
+        this.order.scaleInitLevelSize = this.decoder.readIntOrUndefined();
+        this.order.scaleSubsLevelSize = this.decoder.readIntOrUndefined();
       } else {
-        /* int notSuppScaleNumComponents = */ this.decoder.readIntMax();
-        this.order.scaleInitLevelSize = this.decoder.readIntMax();
+        /* int notSuppScaleNumComponents = */ this.decoder.readIntOrUndefined();
+        this.order.scaleInitLevelSize = this.decoder.readIntOrUndefined();
       }
-      this.order.scalePriceIncrement = this.decoder.readDoubleMax();
+      this.order.scalePriceIncrement = this.decoder.readDoubleOrUndefined();
     }
 
-    if (
-      this.version >= 28 &&
-      this.order.scalePriceIncrement > 0.0 &&
-      this.order.scalePriceIncrement != Number.MAX_VALUE
-    ) {
-      this.order.scalePriceAdjustValue = this.decoder.readDoubleMax();
-      this.order.scalePriceAdjustInterval = this.decoder.readIntMax();
-      this.order.scaleProfitOffset = this.decoder.readDoubleMax();
+    if (this.version >= 28 && this.order.scalePriceIncrement > 0.0) {
+      this.order.scalePriceAdjustValue = this.decoder.readDoubleOrUndefined();
+      this.order.scalePriceAdjustInterval = this.decoder.readIntOrUndefined();
+      this.order.scaleProfitOffset = this.decoder.readDoubleOrUndefined();
       this.order.scaleAutoReset = this.decoder.readBool();
-      this.order.scaleInitPosition = this.decoder.readIntMax();
-      this.order.scaleInitFillQty = this.decoder.readIntMax();
+      this.order.scaleInitPosition = this.decoder.readIntOrUndefined();
+      this.order.scaleInitFillQty = this.decoder.readIntOrUndefined();
       this.order.scaleRandomPercent = this.decoder.readBool();
     }
   }
@@ -3483,20 +3473,25 @@ class OrderDecoder {
       this.readOrderStatus();
 
       if (this.serverVersion >= MIN_SERVER_VER.WHAT_IF_EXT_FIELDS) {
-        this.orderState.initMarginBefore = this.decoder.readDoubleMax();
-        this.orderState.maintMarginBefore = this.decoder.readDoubleMax();
-        this.orderState.equityWithLoanBefore = this.decoder.readDoubleMax();
-        this.orderState.initMarginChange = this.decoder.readDoubleMax();
-        this.orderState.maintMarginChange = this.decoder.readDoubleMax();
-        this.orderState.equityWithLoanChange = this.decoder.readDoubleMax();
+        this.orderState.initMarginBefore = this.decoder.readDoubleOrUndefined();
+        this.orderState.maintMarginBefore =
+          this.decoder.readDoubleOrUndefined();
+        this.orderState.equityWithLoanBefore =
+          this.decoder.readDoubleOrUndefined();
+        this.orderState.initMarginChange = this.decoder.readDoubleOrUndefined();
+        this.orderState.maintMarginChange =
+          this.decoder.readDoubleOrUndefined();
+        this.orderState.equityWithLoanChange =
+          this.decoder.readDoubleOrUndefined();
       }
 
-      this.orderState.initMarginAfter = this.decoder.readDoubleMax();
-      this.orderState.maintMarginAfter = this.decoder.readDoubleMax();
-      this.orderState.equityWithLoanAfter = this.decoder.readDoubleMax();
-      this.orderState.commission = this.decoder.readDoubleMax();
-      this.orderState.minCommission = this.decoder.readDoubleMax();
-      this.orderState.maxCommission = this.decoder.readDoubleMax();
+      this.orderState.initMarginAfter = this.decoder.readDoubleOrUndefined();
+      this.orderState.maintMarginAfter = this.decoder.readDoubleOrUndefined();
+      this.orderState.equityWithLoanAfter =
+        this.decoder.readDoubleOrUndefined();
+      this.orderState.commission = this.decoder.readDoubleOrUndefined();
+      this.orderState.minCommission = this.decoder.readDoubleOrUndefined();
+      this.orderState.maxCommission = this.decoder.readDoubleOrUndefined();
       this.orderState.commissionCurrency = this.decoder.readStr();
       this.orderState.warningText = this.decoder.readStr();
     }
@@ -3648,18 +3643,18 @@ class OrderDecoder {
   readAdjustedOrderParams(): void {
     if (this.serverVersion >= MIN_SERVER_VER.PEGGED_TO_BENCHMARK) {
       this.order.adjustedOrderType = this.decoder.readStr();
-      this.order.triggerPrice = this.decoder.readDoubleMax();
+      this.order.triggerPrice = this.decoder.readDoubleOrUndefined();
       this.readStopPriceAndLmtPriceOffset();
-      this.order.adjustedStopPrice = this.decoder.readDoubleMax();
-      this.order.adjustedStopLimitPrice = this.decoder.readDoubleMax();
-      this.order.adjustedTrailingAmount = this.decoder.readDoubleMax();
+      this.order.adjustedStopPrice = this.decoder.readDoubleOrUndefined();
+      this.order.adjustedStopLimitPrice = this.decoder.readDoubleOrUndefined();
+      this.order.adjustedTrailingAmount = this.decoder.readDoubleOrUndefined();
       this.order.adjustableTrailingUnit = this.decoder.readInt();
     }
   }
 
   readStopPriceAndLmtPriceOffset(): void {
-    this.order.trailStopPrice = this.decoder.readDoubleMax();
-    this.order.lmtPriceOffset = this.decoder.readDoubleMax();
+    this.order.trailStopPrice = this.decoder.readDoubleOrUndefined();
+    this.order.lmtPriceOffset = this.decoder.readDoubleOrUndefined();
   }
 
   readSoftDollarTier(): void {
@@ -3677,7 +3672,7 @@ class OrderDecoder {
 
   readCashQty(): void {
     if (this.serverVersion >= MIN_SERVER_VER.CASH_QTY) {
-      this.order.cashQty = this.decoder.readDoubleMax();
+      this.order.cashQty = this.decoder.readDoubleOrUndefined();
     }
   }
 
@@ -3704,7 +3699,7 @@ class OrderDecoder {
   }
 
   readFilledQuantity(): void {
-    this.order.filledQuantity = this.decoder.readDoubleMax();
+    this.order.filledQuantity = this.decoder.readDoubleOrUndefined();
   }
 
   readRefFuturesConId(): void {

--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -426,50 +426,58 @@ export class Decoder {
    * Read a token from queue and return it as floating point value.
    *
    * Returns 0 if the token is empty.
+   * Returns undefined is the token is Number.MAX_VALUE.
    */
-  readDouble(): number {
+  readDouble(): number | undefined {
     const token = this.readStr();
     if (token === null || token === "") {
       return 0;
     }
-    return parseFloat(token);
+    const val = parseFloat(token);
+    return val === Number.MAX_VALUE ? undefined : val;
   }
 
   /**
-   * Read a token from queue and return it as floating point value,
-   * or undefined if the token is empty.
+   * Read a token from queue and return it as floating point value.
+   *
+   * Returns undefined if the token is empty or Number.MAX_VALUE.
    */
   readDoubleOrUndefined(): number | undefined {
     const token = this.readStr();
     if (token === null || token === "") {
       return undefined;
     }
-    return parseFloat(token);
+    const val = parseFloat(token);
+    return val === Number.MAX_VALUE ? undefined : val;
   }
 
   /**
    * Read a token from queue and return it as integer value.
    *
    * Returns 0 if the token is empty.
+   * Returns undefined is the token is Number.MAX_VALUE.
    */
-  readInt(): number {
+  readInt(): number | undefined {
     const token = this.readStr();
     if (token === null || token === "") {
       return 0;
     }
-    return parseInt(token, 10);
+    const val = parseInt(token, 10);
+    return val === Number.MAX_VALUE ? undefined : val;
   }
 
   /**
    * Read a token from queue and return it as integer value.
-   * or undefined if the token is empty.
+   *
+   * Returns undefined if the token is empty or Number.MAX_VALUE.
    */
   readIntOrUndefined(): number | undefined {
     const token = this.readStr();
     if (token === null || token === "") {
       return undefined;
     }
-    return parseInt(token, 10);
+    const val = parseInt(token, 10);
+    return val === Number.MAX_VALUE ? undefined : val;
   }
 
   /**
@@ -545,7 +553,7 @@ export class Decoder {
       }
     }
 
-    if (sizeTickType !== -1) {
+    if (sizeTickType) {
       this.emit(EventName.tickSize, tickerId, sizeTickType, size);
     }
   }
@@ -2092,7 +2100,14 @@ export class Decoder {
     const articleId = this.readStr();
     const headline = this.readStr();
 
-    this.emit(EventName.historicalNews, requestId, time, providerCode, articleId, headline);
+    this.emit(
+      EventName.historicalNews,
+      requestId,
+      time,
+      providerCode,
+      articleId,
+      headline
+    );
   }
 
   /**

--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -507,12 +507,12 @@ export class Decoder {
     const tickType = this.readInt();
     const price = this.readDouble();
 
-    let size = 0;
+    let size = undefined;
     if (version >= 2) {
       size = this.readInt();
     }
 
-    let canAutoExecute = false;
+    let canAutoExecute = undefined;
     if (version >= 3) {
       canAutoExecute = this.readBool();
     }
@@ -521,7 +521,7 @@ export class Decoder {
 
     this.emit(EventName.tickPrice, tickerId, tickType, price, canAutoExecute);
 
-    let sizeTickType = -1;
+    let sizeTickType = undefined;
     if (version >= 2) {
       switch (tickType) {
         case TickType.BID:
@@ -576,22 +576,22 @@ export class Decoder {
     const remaining = this.readInt();
     const avgFillPrice = this.readDouble();
 
-    let permId = 0;
+    let permId: number | undefined = undefined;
     if (version >= 2) {
       permId = this.readInt();
     }
 
-    let parentId = 0;
+    let parentId: number | undefined = undefined;
     if (version >= 3) {
       parentId = this.readInt();
     }
 
-    let lastFillPrice = 0;
+    let lastFillPrice: number | undefined = undefined;
     if (version >= 4) {
       lastFillPrice = this.readDouble();
     }
 
-    let clientId = 0;
+    let clientId: number | undefined = undefined;
     if (version >= 5) {
       clientId = this.readInt();
     }
@@ -1064,7 +1064,7 @@ export class Decoder {
     const price = this.readDouble();
     const size = this.readInt();
 
-    let isSmartDepth = false;
+    let isSmartDepth = undefined;
     if (this.serverVersion >= MIN_SERVER_VER.SMART_DEPTH) {
       isSmartDepth = this.readBool();
     }
@@ -1157,7 +1157,7 @@ export class Decoder {
         hasGaps = this.readBool();
       }
 
-      let barCount = -1;
+      let barCount: number | undefined = undefined;
       if (version >= 3) {
         barCount = this.readInt();
       }
@@ -2086,16 +2086,13 @@ export class Decoder {
    * Decode a HISTORICAL_NEWS message from data queue and emit a historicalNews event.
    */
   private decodeMsg_HISTORICAL_NEWS(): void {
-    const nNewsProviders = this.readInt();
-    const newProviders: NewsProvider[] = new Array(nNewsProviders);
-    for (let i = 0; i < nNewsProviders; i++) {
-      newProviders[i] = {
-        providerCode: this.readStr(),
-        providerName: this.readStr(),
-      };
-    }
+    const requestId = this.readInt();
+    const time = this.readStr();
+    const providerCode = this.readStr();
+    const articleId = this.readStr();
+    const headline = this.readStr();
 
-    this.emit(EventName.historicalNews, newProviders);
+    this.emit(EventName.historicalNews, requestId, time, providerCode, articleId, headline);
   }
 
   /**

--- a/src/core/io/encoder.ts
+++ b/src/core/io/encoder.ts
@@ -107,8 +107,13 @@ export enum OUT_MSG_ID {
  * @@internal
  *
  * Helper function to nullify a number of Number.MAX_VALUE
+ *
+ * Note that this is still there for legacy reason.
+ * With v1.2.1, Number.MAX_VALUE has been dropped and replaced with undefined on decoder-side,
+ * but we still support it on encoder-side to avoid any unreasonably large numbers submitted to
+ * TWS if any client code was not migrated.
  */
-function nullifyMax(number): number | null {
+function nullifyMax(number?: number): number | null {
   if (number === Number.MAX_VALUE) {
     return null;
   } else {
@@ -931,7 +936,7 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
     }
 
     if (this.serverVersion < MIN_SERVER_VER.CASH_QTY) {
-      if (order.cashQty !== undefined && order.cashQty != Number.MAX_VALUE) {
+      if (order.cashQty !== undefined) {
         return this.emitError(
           "It does not support cash quantity parameter",
           ErrorCode.UPDATE_TWS,
@@ -1213,11 +1218,11 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
       // Volatility orders had specific watermark price attribs in server version 26
       const lower =
         this.serverVersion === 26 && order.orderType === "VOL"
-          ? Number.MAX_VALUE
+          ? undefined
           : order.stockRangeLower;
       const upper =
         this.serverVersion === 26 && order.orderType === "VOL"
-          ? Number.MAX_VALUE
+          ? undefined
           : order.stockRangeUpper;
       tokens.push(lower);
       tokens.push(upper);
@@ -1264,9 +1269,9 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
       if (this.serverVersion === 26) {
         // Volatility orders had specific watermark price attribs in server version 26
         const lower =
-          order.orderType === "VOL" ? order.stockRangeLower : Number.MAX_VALUE;
+          order.orderType === "VOL" ? order.stockRangeLower : undefined;
         const upper =
-          order.orderType === "VOL" ? order.stockRangeUpper : Number.MAX_VALUE;
+          order.orderType === "VOL" ? order.stockRangeUpper : undefined;
         tokens.push(nullifyMax(lower));
         tokens.push(nullifyMax(upper));
       }
@@ -1296,8 +1301,7 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
 
     if (
       this.serverVersion >= MIN_SERVER_VER.SCALE_ORDERS3 &&
-      order.scalePriceIncrement != null &&
-      order.scalePriceIncrement !== Number.MAX_VALUE
+      order.scalePriceIncrement !== undefined
     ) {
       tokens.push(nullifyMax(order.scalePriceAdjustValue));
       tokens.push(nullifyMax(order.scalePriceAdjustInterval));


### PR DESCRIPTION
**This PR introduces a breaking change**
Because of the breaking change, I have pushed version to 1.2.0

Since we receive too many questions & "bug reports" about values set to Number.MAX_VALUE, we will drop this and use undefined instead. Number.MAX_VALUE was used for values that are not available. It was implemented like that to be in-sync with the official TWS Java API, however checking Number.MAX_VALUE is very uncommon in JScript/TS as everyone would expect `undefined` instead.
So this PR removes Number.MAX_VALUE and replaces it with undefined.

Affects:
IBApi decoder: readDoubleMax / readIntMax has been replaced with readDoubleOrUndefined / readIntOrUndefined
IBApi encoder: encoder still supports Number.MAX_VALUE and will continue to do so for some time. This is to avoid that we submit any insane large numbers to TWS if the client code still uses Number.MAX_VALUE to e.g. create an order.
IBApiNext: undefineMax has been removed as not needed anymore.
README: removed info about Number.MAX_VALUE and add note about the breaking change when upgrading from1.1.x to 1.2.x
