### PR TITLE
Fix OPEN_ORDER decoding

### DIFF
--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -3354,8 +3354,9 @@ class OrderDecoder {
             exemptCode,
           });
         }
-
-        const orderComboLegsCount = this.decoder.readInt();
+      }
+      
+      const orderComboLegsCount = this.decoder.readInt();
         if (orderComboLegsCount > 0) {
           this.order.orderComboLegs = [];
           for (let i = 0; i < orderComboLegsCount; ++i) {
@@ -3366,7 +3367,6 @@ class OrderDecoder {
             });
           }
         }
-      }
     }
   }
 

--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -3459,6 +3459,7 @@ class OrderDecoder {
       if (this.order.algoStrategy && this.order.algoStrategy !== "") {
         const algoParamsCount = this.decoder.readInt();
         if (algoParamsCount > 0) {
+          this.order.algoParams = [];
           for (let i = 0; i < algoParamsCount; ++i) {
             const tag = this.decoder.readStr();
             const value = this.decoder.readStr();


### PR DESCRIPTION
Work-in-progress PR, not sloved yet.

See https://github.com/stoqey/ib/issues/122

How to test:
Copy this to start() of some app on tools folder ad run it:
```
import { Decoder } from "../core/io/decoder";
..
start(): void {
 const dec = new Decoder({
      serverVersion: 164,
      emitEvent(eventName: EventName, ...args: unknown[]) {
        return;
      },
      emitError(errMsg: string, code: number, reqId: number) {
        return;
      },
      emitInfo(message: string) {
        return;
      },
    });
    dec.enqueueMessage([
      "5",
      "19",
      "172520988",
      "XRTK",
      "STK",
      "",
      "0",
      "?",
      "",
      "CSFBALGO",
      "USD",
      "XRTK",
      "NMS",
      "SELL",
      "300",
      "LMT",
      "3.95",
      "0.0",
      "DAY",
      "",
      "UXXXXXXXX",
      "",
      "0",
      "",
      "0",
      "236990421",
      "0",
      "0",
      "0",
      "",
      "236990421.0/UXXXXXXXX/100",
      "",
      "",
      "",
      "",
      "",
      "",
      "0",
      "",
      "",
      "0",
      "",
      "-1",
      "0",
      "",
      "",
      "",
      "",
      "",
      "",
      "0",
      "0",
      "0",
      "",
      "3",
      "0",
      "0",
      "",
      "0",
      "0",
      "",
      "0",
      "None",
      "",
      "0",
      "",
      "",
      "",
      "?",
      "0",
      "0",
      "",
      "0",
      "0",
      "",
      "",
      "",
      "",
      "",
      "0",
      "0",
      "0",
      "",
      "",
      "",
      "",
      "0",
      "",
      "IB",
      "0",
      "0",
      "CROSSFINDER+",
      "3",
      "Blockfinder",
      "0",
      "ExecStyle",
      "Normal",
      "DisplaySize",
      "100",
      "0",
      "0",
      "PreSubmitted",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "",
      "",
      "",
      "",
      "",
      "0",
      "0",
      "0",
      "None",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "1.7976931348623157E308",
      "0",
      "",
      "",
      "",
      "0",
      "1",
      "0",
      "0",
      "1",
      undefined,
    ]);
    dec.process();
}
```
Set a breakpoint on decodeMsg_OPEN_ORDER on decoder.ts and run it on debuger.
Problem: at end of decodeMsg_OPEN_ORDER there is still data left on dec.dataQueue but it must be empty.

Current state: I think we miss to read one token in between orderDecoder.readVolOrderParams(true); and orderDecoder.readAlgoParams(); but can't figure out where.
Why I think that: if you step through the decoder and look at attribute assigments, the last one that can be matches by value (before something goes wrong) is 'None' on deltaNeutralOrderType.  From there I want to follow until I hit 'IB' assigned to clearingIntent (next "match by value")
Here the data as parsed by decoder:
```
[
readOrderId
  '19', readOrderId
readContractFields
  '172520988', conId
  'XRTK', symbol
  'STK', secType
  '', lastTradeDateOrContractMonth
  '0', strike
  '?', right
  '', multiplier
  'CSFBALGO', exchange
  'USD', currency
  'XRTK', localSymbol
  'NMS', tradingClass
readAction
  'SELL', action
readTotalQuantity
  '300', totalQuantity
readOrderType
  'LMT', orderType
readLmtPrice
  '3.95', lmtPrice
readAuxPrice
  '0.0', auxPrice
readTIF
  'DAY', tif
readOcaGroup
  '', ocaGroup
readAccount
  'UXXXXXXXX', account
readOpenClose
  '', openClose
readOrigin
  '0', origin
readOrderRef
  '', orderRef
readClientId
  '0', clientId
readPermId
  '236990421', permId
readOutsideRth
  '0', outsideRth
readHidden
  '0', hidden
readDiscretionaryAmount
  '0', discretionaryAmt
readGoodAfterTime
  '', goodAfterTime
skipSharesAllocation
  '236990421.0/UXXXXXXXX/100', sharesAllocation
readFAParams
  '', faGroup
  '', faMethod
  '', faPercentage
  '', faProfile
readModelCode
  '', modelCode
readGoodTillDate
  '', goodTillDate
readRule80A
  '0', rule80A
readPercentOffset
  '', percentOffset
readSettlingFirm
  '', settlingFirm
readShortSaleParams
  '0', shortSaleSlot
  '', designatedLocation
  '-1', exemptCode
readAuctionStrategy
  '0', auctionStrategy
readBoxOrderParams
  '', startingPrice
  '', stockRefPrice
  '', delta
readPegToStkOrVolOrderParams
  '', stockRangeLower
  '', stockRangeUpper
readDisplaySize
  '', displaySize
readOldStyleOutsideRth // will never happen
readBlockOrder
  '0', blockOrder
readSweepToFill
  '0', sweepToFill
readAllOrNone
  '0', allOrNone
readMinQty
  '', minQty
readOcaType
  '3', ocaType
readETradeOnly
  '0', eTradeOnly
readFirmQuoteOnly
  '0', firmQuoteOnly
readNbboPriceCap
  '', nbboPriceCap
readParentId
  '0', parentId
readTriggerMethod
  '0', triggerMethod
readVolOrderParams
  '', volatility
  '0', volatilityType
  'None', deltaNeutralOrderType
  '', deltaNeutralAuxPrice
  '0', deltaNeutralConId
  '', deltaNeutralSettlingFirm
  '', deltaNeutralClearingAccount
  '', deltaNeutralClearingIntent
  '?', deltaNeutralOpenClose
  '0', deltaNeutralShortSale
  '0', deltaNeutralShortSaleSlot
  '', deltaNeutralDesignatedLocation
  '0', continuousUpdate
  '0', referencePriceType
readTrailParams
  '', trailStopPrice
  '', trailingPercent
readBasisPoints
  '', basisPoints
  '', basisPointsType
readComboLegs
  '', comboLegsDescription
  '0', comboLegsCount
readSmartComboRoutingParams
  '0', smartComboRoutingParamsCount
readScaleOrderParams
  '0', scaleInitLevelSize
  '', scaleSubsLevelSize
  '', scalePriceIncrement
readHedgeParams
  '' hedgeType
readOptOutSmartRouting
  '' optOutSmartRouting (this is suspicious, should be bool)
readClearingParams
  '0', optOutSmartRouting
  '',  clearingIntent -> THIS WONG, it must be "IB"
  'IB',
```
So.. up to readVolOrderParams/deltaNeutralOrderType it seems fine. When we arrive at readClearingParams/clearingIntent we are one too late.
If I add a dummy read, the message can be parsed successfully (including the algoParams).. it's the issue definitly is there we miss one token, in between readVolOrderParams (seem ok) and readClearingParams, but readClearingParams latest.
 
Happy debug stepping, maybe someone else finds it.
Here is the original java code, the decodeMsg_OPEN_ORDER decoder.ts must to same https://github.com/stoqey/ib/blob/master/ref/client/EDecoder.java#L1341 https://github.com/stoqey/ib/blob/master/ref/client/EOrderDecoder.java (but looks like it doesn't as we miss one token)






