### PR TITLE
fix: Ignore configuration file read error, when yarn+PnP is used

### DIFF
--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -47,7 +47,7 @@ function readJson(readPath: string) {
   } catch (error) {
     if (
       error.code !== "ENOENT" ||
-      (error.errno !== -4058 && error.errno !== -2)
+      (error.errno !== undefined && error.errno !== -4058 && error.errno !== -2)
     ) {
       throw error;
     }


### PR DESCRIPTION
Hi!

When the yarn + PnP is used, `@stoqey/ib` fails to ignore the configuration file read error, because the `errno` is undefined and the error is thrown.

```text
/home/user/dev/project/.pnp.cjs:11799
  return Object.assign(new Error(`${code}: ${message}`), {code});
                       ^

Error: ENOENT: no such file or directory, open '/node_modules/@stoqey/ib/config/default.json'
    at makeError$1 (/home/user/dev/project/.pnp.cjs:11799:24)
    at ENOENT (/home/user/dev/project/.pnp.cjs:11814:10)
    at ZipFS.resolveFilename (/home/user/dev/project/.pnp.cjs:13355:15)
    at ZipFS.readFileBuffer (/home/user/dev/project/.pnp.cjs:13761:28)
    at ZipFS.readFileSync (/home/user/dev/project/.pnp.cjs:13755:23)
    at /home/user/dev/project/.pnp.cjs:14750:20
    at /home/user/dev/project/.pnp.cjs:14840:60
    at ZipOpenFS.getZipSync (/home/user/dev/project/.pnp.cjs:14969:14)
    at ZipOpenFS.makeCallSync (/home/user/dev/project/.pnp.cjs:14840:17)
    at ZipOpenFS.readFileSync (/home/user/dev/project/.pnp.cjs:14742:17) {
  code: 'ENOENT'
}
```