### PR TITLE
Fixed reqHeadTimestamp and reqHistogramData

### DIFF
--- a/src/core/io/encoder.ts
+++ b/src/core/io/encoder.ts
@@ -216,12 +216,11 @@ export class Encoder {
       contract.right,
       contract.multiplier,
       contract.exchange,
+      contract.primaryExch,
       contract.currency,
       contract.localSymbol,
       contract.tradingClass,
-      contract.primaryExch,
-      contract.secIdType,
-      contract.secId,
+      contract.includeExpired ? 1 : 0,
     ];
   }
 
@@ -1856,8 +1855,8 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
       OUT_MSG_ID.REQ_HEAD_TIMESTAMP,
       reqId,
       this.encodeContract(contract),
-      whatToShow,
       useRTH ? 1 : 0,
+      whatToShow,
       formatDate,
     );
   }
@@ -3127,8 +3126,8 @@ function tagValuesToTokens(tagValues: TagValue[]): unknown[] {
       OUT_MSG_ID.REQ_HISTOGRAM_DATA,
       tickerId,
       this.encodeContract(contract),
-      timePeriod,
       useRTH ? 1 : 0,
+      timePeriod,
     );
   }
 

--- a/src/tests/unit/api/head-timestamp.test.ts
+++ b/src/tests/unit/api/head-timestamp.test.ts
@@ -1,0 +1,53 @@
+/**
+ * This file implement test code for the public API interfaces.
+ */
+import { Contract, EventName, IBApi, Stock, WhatToShow } from "../../..";
+import configuration from "../../../common/configuration";
+
+describe("IBApi Historical data Tests", () => {
+  jest.setTimeout(10 * 1000);
+
+  let ib: IBApi;
+  const clientId = Math.floor(Math.random() * 32766) + 1; // ensure unique client
+
+  beforeEach(() => {
+    ib = new IBApi({
+      host: configuration.ib_host,
+      port: configuration.ib_port,
+      clientId,
+    });
+    // logger.info("IBApi created");
+  });
+
+  afterEach(() => {
+    if (ib) {
+      ib.disconnect();
+      ib = undefined;
+    }
+    // logger.info("IBApi disconnected");
+  });
+
+  it("Returns the correct head timestamp", (done) => {
+    const referenceID = 42;
+
+    ib.once(EventName.connected, () => {
+      const contract: Contract = new Stock("AAPL");
+
+      ib.reqHeadTimestamp(referenceID, contract, WhatToShow.TRADES, true, 2)
+        .on(EventName.headTimestamp, (requestId, headTimestamp) => {
+          if (requestId === referenceID) {
+            expect(headTimestamp).toEqual("345479400");
+            ib.disconnect();
+          }
+        })
+        .on(EventName.disconnected, done)
+        .on(EventName.error, (err, code, requestId) => {
+          if (requestId === referenceID) {
+            done(`[${requestId}] ${err.message} (#${code})`);
+          }
+        });
+    });
+
+    ib.connect();
+  });
+});

--- a/src/tests/unit/api/histogram-data.test.ts
+++ b/src/tests/unit/api/histogram-data.test.ts
@@ -1,0 +1,54 @@
+/**
+ * This file implement test code for the public API interfaces.
+ */
+import { Contract, DurationUnit, EventName, IBApi, Stock } from "../../..";
+import configuration from "../../../common/configuration";
+
+describe("IBApi Histogram data Tests", () => {
+  jest.setTimeout(10 * 1000);
+
+  let ib: IBApi;
+  const clientId = Math.floor(Math.random() * 32766) + 1; // ensure unique client
+
+  beforeEach(() => {
+    ib = new IBApi({
+      host: configuration.ib_host,
+      port: configuration.ib_port,
+      clientId,
+    });
+    // logger.info("IBApi created");
+  });
+
+  afterEach(() => {
+    if (ib) {
+      ib.disconnect();
+      ib = undefined;
+    }
+    // logger.info("IBApi disconnected");
+  });
+
+  it("Histogram market data", (done) => {
+    const referenceID = 46;
+
+    ib.once(EventName.connected, () => {
+      const contract: Contract = new Stock("AAPL");
+
+      ib.reqHistogramData(referenceID, contract, true, 1, DurationUnit.WEEK)
+        .on(EventName.histogramData, (requestID, data) => {
+          if (requestID === referenceID) {
+            expect(requestID).toEqual(referenceID);
+            expect(data.length).toBeGreaterThan(0);
+            ib.disconnect();
+          }
+        })
+        .on(EventName.disconnected, done)
+        .on(EventName.error, (err, code, requestID) => {
+          if (requestID == referenceID) {
+            done(`[${requestID}] ${err.message} (#${code})`);
+          }
+        });
+    });
+
+    ib.connect();
+  });
+});


### PR DESCRIPTION
Adapted the encoding of a contract to match the code of the Java client. Fixed the order of values in reqHeadTimestamp and reqHistogramData to match the Java client.

I added unit tests, which work, but I could not get the full test suite to pass locally (e.g. requesting News). Probably some account restrictions.
