### PR TITLE
fix(multiplier): readInt to readDouble

### DIFF
--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -132,7 +132,7 @@ export class Decoder {
    *
    * @param callback A [[DecoderCallbacks]] implementation.
    */
-  constructor(private callback: DecoderCallbacks) { }
+  constructor(private callback: DecoderCallbacks) {}
 
   /**
    * Input data queue.
@@ -379,7 +379,8 @@ export class Decoder {
         if (verifyMessageBoundary) {
           if (this.dataQueue[0] !== undefined) {
             this.callback.emitError(
-              `Decoding error on ${IN_MSG_ID[msgId]
+              `Decoding error on ${
+                IN_MSG_ID[msgId]
               }: unprocessed data left on queue (${JSON.stringify(
                 this.dataQueue,
               )}). Please report to https://github.com/stoqey/ib`,
@@ -2765,7 +2766,7 @@ class OrderDecoder {
     private orderState: OrderState,
     private version: number,
     private serverVersion: number,
-  ) { }
+  ) {}
 
   readOrderId(): void {
     this.order.orderId = this.decoder.readInt();

--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -132,7 +132,7 @@ export class Decoder {
    *
    * @param callback A [[DecoderCallbacks]] implementation.
    */
-  constructor(private callback: DecoderCallbacks) {}
+  constructor(private callback: DecoderCallbacks) { }
 
   /**
    * Input data queue.
@@ -379,8 +379,7 @@ export class Decoder {
         if (verifyMessageBoundary) {
           if (this.dataQueue[0] !== undefined) {
             this.callback.emitError(
-              `Decoding error on ${
-                IN_MSG_ID[msgId]
+              `Decoding error on ${IN_MSG_ID[msgId]
               }: unprocessed data left on queue (${JSON.stringify(
                 this.dataQueue,
               )}). Please report to https://github.com/stoqey/ib`,
@@ -871,7 +870,7 @@ export class Decoder {
     contract.right = validateOptionType(this.readStr() as OptionType);
 
     if (version >= 7) {
-      contract.multiplier = this.readInt();
+      contract.multiplier = this.readDouble();
       contract.primaryExch = this.readStr();
     }
 
@@ -979,7 +978,7 @@ export class Decoder {
     ) {
       this.readInt(); // mdSizeMultiplier - not used anymore
     }
-    contract.contract.multiplier = this.readInt();
+    contract.contract.multiplier = this.readDouble();
     contract.orderTypes = this.readStr();
     contract.validExchanges = this.readStr();
 
@@ -1132,7 +1131,7 @@ export class Decoder {
     contract.right = validateOptionType(this.readStr() as OptionType);
 
     if (version >= 9) {
-      contract.multiplier = this.readInt();
+      contract.multiplier = this.readDouble();
     }
 
     contract.exchange = this.readStr();
@@ -1894,7 +1893,7 @@ export class Decoder {
     contract.lastTradeDateOrContractMonth = this.readStr();
     contract.strike = this.readDouble();
     contract.right = validateOptionType(this.readStr() as OptionType);
-    contract.multiplier = this.readInt();
+    contract.multiplier = this.readDouble();
     contract.exchange = this.readStr();
     contract.currency = this.readStr();
     contract.localSymbol = this.readStr();
@@ -1982,7 +1981,7 @@ export class Decoder {
     contract.lastTradeDateOrContractMonth = this.readStr();
     contract.strike = this.readDouble();
     contract.right = validateOptionType(this.readStr() as OptionType);
-    contract.multiplier = this.readInt();
+    contract.multiplier = this.readDouble();
     contract.exchange = this.readStr();
     contract.currency = this.readStr();
     contract.localSymbol = this.readStr();
@@ -2053,7 +2052,7 @@ export class Decoder {
     const exchange = this.readStr();
     const underlyingConId = this.readInt();
     const tradingClass = this.readStr();
-    const multiplier = this.readStr();
+    const multiplier = this.readDouble();
     const expCount = this.readInt();
     const expirations: unknown[] = [];
 
@@ -2766,7 +2765,7 @@ class OrderDecoder {
     private orderState: OrderState,
     private version: number,
     private serverVersion: number,
-  ) {}
+  ) { }
 
   readOrderId(): void {
     this.order.orderId = this.decoder.readInt();


### PR DESCRIPTION
BUG: There's a bug in TWS, when a contract has a multiplier as a float e.g `0.1`, ib returns it as `0`

**FIX: replace readInt with readDouble**


PS: `decodeMsg_SECURITY_DEFINITION_OPTION_PARAMETER` had a `readStr` i changed it to `readDouble` too


