### PR TITLE
fix(watchdog): keep connected, reconnect with code 1100/2110

### DIFF
--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -232,8 +232,13 @@ export class IBApiNext {
     });
 
     // setup TWS info message event handler  (bound to lifetime of IBApiAutoConnection so we never unregister)
-
     this.api.on(EventName.info, (message: string, code: number) => {
+      if (
+        code === ErrorCode.FAIL_CONNECTION_LOST_BETWEEN_SERVER_AND_TWS ||
+        code === ErrorCode.FAIL_CONNECTION_LOST_BETWEEN_TWS_AND_SERVER
+      ) {
+        this.api.onDisconnected();
+      }
       this.logger.info(TWS_LOG_TAG, `${message} - Code: ${code}`);
     });
   }

--- a/src/common/errorCode.ts
+++ b/src/common/errorCode.ts
@@ -292,6 +292,17 @@ export enum ErrorCode {
   /** Failed to read message because not connected */
   FAIL_READ_MESSAGE = 586,
 
+  /** Connectivity between IBKR and Trader Workstation has been lost.
+   * @When client is connected to TWS and server but TWS losses connection to server.
+   * 🗣️🗣️🗣️ "Market data connection lost".
+   */
+  FAIL_CONNECTION_LOST_BETWEEN_SERVER_AND_TWS = 1100,
+
+  /** Connectivity between Trader Workstation and server is broken. It will be restored automatically.
+   * @When client connects to TWS but TWS isn't connected to server.
+   */
+  FAIL_CONNECTION_LOST_BETWEEN_TWS_AND_SERVER = 2110,
+
   /** Invalid position trade derived value */
   INVALID_POSITION_TRADE_DERIVATED_VALUE = 2150,
 

--- a/src/core/api-next/auto-connection.ts
+++ b/src/core/api-next/auto-connection.ts
@@ -70,8 +70,6 @@ export class IBApiAutoConnection extends IBApi {
 
   /** Ingress timestamp of last received message data from TWS. */
   private lastDataIngressTm?: number;
-  private lastDataWatchdogTm?: number;
-  private lastDataWatchdogTmCount?: number = 0;
 
   /** The connection-state [[BehaviorSubject]]. */
   private readonly _connectionState = new BehaviorSubject<ConnectionState>(
@@ -250,27 +248,7 @@ export class IBApiAutoConnection extends IBApi {
           "Connection watchdog timeout. Dropping connection.",
         );
         this.onDisconnected();
-      } else {
-        if (this.lastDataWatchdogTm === this.lastDataIngressTm) {
-          if (this.lastDataWatchdogTmCount <= 10) {
-            this.lastDataWatchdogTmCount++;
-            this.logger.debug(
-              LOG_TAG,
-              `Connection watchdog: last data ingress time ${this.lastDataIngressTm}`,
-            );
-          } else {
-            this.logger.debug(
-              LOG_TAG,
-              "Connection watchdog: no new data. Dropping connection.",
-            );
-            this.onDisconnected();
-          }
-        } else {
-          this.lastDataWatchdogTmCount = 0;
-        }
       }
-
-      this.lastDataWatchdogTm = this.lastDataIngressTm;
       // trigger at least some message if connection is idle
       this.reqCurrentTime();
     }, this.watchdogInterval / 2);
@@ -295,7 +273,7 @@ export class IBApiAutoConnection extends IBApi {
    * Called when an [[EventName.disconnected]] event has been received,
    * or the connection-watchdog has detected a dead connection.
    */
-  private onDisconnected(): void {
+  public onDisconnected(): void {
     this.logger.debug(LOG_TAG, "onDisconnected()");
 
     // verify state and update state


### PR DESCRIPTION
BUGS: 

1. 
- When you set a `reconnectInterval: 1000, connectionWatchdogInterval: 1`, even if you're connected runWatchdog disconnects and tries to create a new connection.
- **FIX:** If we already have a connection, no need to trigger reconnect, we should keep the current connection.

2. 
- When you're connected and you lose internet connection (e.i TWS loses connection to IBKR servers), it takes a while for `Socket.onEnd` to get triggered, but TWS already sends code 1100 and 2110)
- **FIX**: if we receive codes 1100/2110, it means we're not connected to the server, we trigger watchdog to try and reconnect.

