### PR TITLE
fix(`getHistoricalTicksLast`): Fix date types

### DIFF
--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -2082,8 +2082,8 @@ export class IBApiNext {
    */
   getHistoricalTicksLast(
     contract: Contract,
-    startDateTime: string,
-    endDateTime: string,
+    startDateTime: string | null,
+    endDateTime: string | null,
     numberOfTicks: number,
     useRTH: number | boolean,
   ): Observable<HistoricalTickLast[]> {


### PR DESCRIPTION
Only one date is allowed in TWS API.

In their docs they use "" for the empty date in Python API and null in C# API. I'm assuming both are ok.

https://interactivebrokers.github.io/tws-api/historical_time_and_sales.html

Related PR: https://github.com/stoqey/ibkr/pull/96