### PR TITLE
Decrease history updates request duration

### DIFF
--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1887,7 +1887,7 @@ export class IBApiNext {
             reqId,
             contract,
             "",
-            "1 D",
+            "60 S",
             barSizeSetting,
             whatToShow,
             0,


### PR DESCRIPTION
When requesting live data updates, using "1 D" can result in request throttling and long response times, especially when requesting a large amount of data.