### PR TITLE
Include `tickAttrib` in tickOptionComputation event and typings

### DIFF
--- a/.ai/changelogs/2026-06-16-tick-option-computation-attrib.md
+++ b/.ai/changelogs/2026-06-16-tick-option-computation-attrib.md
@@ -1,0 +1,6 @@
+# 2026-06-16 tick option computation attrib
+
+- summary: Include `tickAttrib` in `tickOptionComputation` event emissions and typings so option computation values stay aligned.
+- notable files or areas changed: `src/core/io/decoder.ts`, `src/api/api.ts`, `src/api-next/api-next.ts`, targeted unit tests.
+- tests run: `yarn jest src/tests/unit/tick-option-computation-decoder.test.ts src/tests/unit/api-next/get-market-data.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`; `yarn type-check`.
+- risks or follow-ups: `tickAttrib` is passed through but remains unused by the API-next market data mapping.

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1223,6 +1223,7 @@ export class IBApiNext {
     subscriptions: Map<number, IBApiNextSubscription<MutableMarketData>>,
     reqId: number,
     field: number,
+    _tickAttrib: number | undefined,
     impliedVolatility: number,
     delta: number,
     optPrice: number,

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3172,6 +3172,8 @@ export declare interface IBApi {
    * Pass the field value into [[TickType.getField]] to retrieve the field description.
    * For example, a field value of 13 will map to modelOptComp, etc. 10 = Bid 11 = Ask 12 = Last
    *
+   * tickAttrib: 0 - return based, 1 - price based.
+   *
    * impliedVolatility: The implied volatility calculated by the TWS option modeler, using the specified tick type
    *   value.
    *
@@ -3198,6 +3200,7 @@ export declare interface IBApi {
     listener: (
       reqId: number,
       field: TickType,
+      tickAttrib: number | undefined,
       impliedVolatility?: number,
       delta?: number,
       optPrice?: number,

--- a/src/core/io/decoder.ts
+++ b/src/core/io/decoder.ts
@@ -1673,7 +1673,7 @@ export class Decoder {
       EventName.tickOptionComputation,
       tickerId,
       tickType,
-      // tickAttrib,	0 - return based, 1- price based. Ignored
+      _tickAttrib,
       impliedVol,
       delta,
       optPrice,

--- a/src/tests/unit/api-next/get-market-data.test.ts
+++ b/src/tests/unit/api-next/get-market-data.test.ts
@@ -152,6 +152,7 @@ describe("RxJS Wrapper: getMarketData()", () => {
 
     // emit a tickOptionComputationHandler events and verify RxJS result
 
+    const tickAttrib = 1;
     const impliedVolatility = 1;
     const delta = 2;
     const optPrice = 3;
@@ -213,6 +214,7 @@ describe("RxJS Wrapper: getMarketData()", () => {
       EventName.tickOptionComputation,
       1,
       IBApiTickType.BID_OPTION,
+      tickAttrib,
       impliedVolatility,
       delta,
       optPrice,

--- a/src/tests/unit/tick-option-computation-decoder.test.ts
+++ b/src/tests/unit/tick-option-computation-decoder.test.ts
@@ -1,0 +1,49 @@
+import { EventName } from "../../api/data/enum/event-name";
+import MIN_SERVER_VER from "../../api/data/enum/min-server-version";
+import TickType from "../../api/market/tickType";
+import { Decoder } from "../../core/io/decoder";
+import { IN_MSG_ID } from "../../core/io/enum/in-msg-id";
+
+describe("Decoder tickOptionComputation", () => {
+  test("emits tickAttrib before option computation values", () => {
+    const emitEvent = jest.fn();
+    const decoder = new Decoder({
+      serverVersion: MIN_SERVER_VER.PRICE_BASED_VOLATILITY,
+      emitEvent,
+      emitError: jest.fn(),
+      emitInfo: jest.fn(),
+    });
+
+    decoder.enqueueMessage([
+      String(IN_MSG_ID.TICK_OPTION_COMPUTATION),
+      "1",
+      String(TickType.BID_OPTION),
+      "1",
+      "0.25",
+      "0.5",
+      "1.5",
+      "0.75",
+      "0.1",
+      "0.2",
+      "0.3",
+      "100",
+    ]);
+
+    decoder.process();
+
+    expect(emitEvent).toHaveBeenCalledWith(
+      EventName.tickOptionComputation,
+      1,
+      TickType.BID_OPTION,
+      1,
+      0.25,
+      0.5,
+      1.5,
+      0.75,
+      0.1,
+      0.2,
+      0.3,
+      100,
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- The decoder emitted a `tickAttrib` value for `TICK_OPTION_COMPUTATION` but it was not forwarded into the public event arguments, which misaligned subsequent option computation fields.  
- Ensure the event signature and consumers receive the attribute so decoded values remain aligned with the TWS protocol ordering.

### Description
- Forward the decoded `tickAttrib` from the decoder emit call by adding the argument to `tickOptionComputation` emissions in `src/core/io/decoder.ts` (`_tickAttrib`).
- Update the `IBApi` listener signature and JSDoc in `src/api/api.ts` to include `tickAttrib` between `field` and `impliedVolatility`.
- Accept the added argument in the API-next handler by updating the `onTickOptionComputation` signature in `src/api-next/api-next.ts` (parameter named `_tickAttrib`) while keeping current market-data mapping unchanged.
- Add a unit test for decoder ordering and update the existing API-next market data test to include `tickAttrib`, and add an AI changelog entry under `.ai/changelogs`.

### Testing
- Ran targeted Jest tests: `yarn jest src/tests/unit/tick-option-computation-decoder.test.ts src/tests/unit/api-next/get-market-data.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`, both passed.
- Ran static type checks via `yarn type-check`, which succeeded.
- Verified updated tests exercise the new `tickAttrib` argument and confirm decoder emits and API-next handling keep option computation values aligned.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30f14b8ca4832982e07f8796fa9240)