### PR TITLE
fix(api): export Crypto and align Index constructor args

### DIFF
--- a/.ai/changelogs/2026-06-16-contract-exports.md
+++ b/.ai/changelogs/2026-06-16-contract-exports.md
@@ -1,0 +1,6 @@
+# 2026-06-16 contract exports
+
+- Summary: exported `Crypto` from the package API and aligned `Index` constructor argument order with the other simple contract classes.
+- Notable files: `src/index.ts`, `src/api/contract/ind.ts`, `src/tests/unit/api/contract-api.test.ts`, `src/tests/unit/sample-data/contracts.ts`.
+- Tests run: targeted Jest contract API test.
+- Risks or follow-ups: `Index` callers using the previous exchange/currency argument order should update to `new Index(symbol, exchange, currency)`.

--- a/src/api/contract/ind.ts
+++ b/src/api/contract/ind.ts
@@ -7,8 +7,8 @@ import { Contract } from "./contract";
 export class Index implements Contract {
   constructor(
     public symbol: string,
-    public currency?: string,
     public exchange?: string,
+    public currency?: string,
   ) {
     this.currency = this.currency ?? "USD";
     this.exchange = this.exchange ?? "CME";

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export { Bond } from "./api/contract/bond";
 export { CFD } from "./api/contract/cfd";
 export { Combo } from "./api/contract/combo";
 export { ComboLeg } from "./api/contract/comboLeg";
+export { Crypto } from "./api/contract/crypto";
 export { Contract } from "./api/contract/contract";
 export { ContractDescription } from "./api/contract/contractDescription";
 export { ContractDetails } from "./api/contract/contractDetails";

--- a/src/tests/unit/api/contract-api.test.ts
+++ b/src/tests/unit/api/contract-api.test.ts
@@ -1,0 +1,25 @@
+import { Crypto, Index, SecType } from "../../..";
+
+describe("contract API exports", () => {
+  test("exports Crypto from the package API", () => {
+    const contract = new Crypto("BTC");
+
+    expect(contract).toMatchObject({
+      symbol: "BTC",
+      exchange: "PAXOS",
+      currency: "USD",
+      secType: SecType.CRYPTO,
+    });
+  });
+
+  test("uses exchange before currency for Index constructor arguments", () => {
+    const contract = new Index("DAX", "EUREX", "EUR");
+
+    expect(contract).toMatchObject({
+      symbol: "DAX",
+      exchange: "EUREX",
+      currency: "EUR",
+      secType: SecType.IND,
+    });
+  });
+});

--- a/src/tests/unit/sample-data/contracts.ts
+++ b/src/tests/unit/sample-data/contracts.ts
@@ -4,6 +4,7 @@
 import {
   Bond,
   Contract,
+  Crypto,
   Future,
   Index,
   Option,
@@ -11,13 +12,12 @@ import {
   SecType,
   Stock,
 } from "../../..";
-import Crypto from "../../../api/contract/crypto";
 
 export const sample_stock: Contract = new Stock("AAPL");
 export const sample_etf: Contract = new Stock("SPY");
 export const sample_bond: Contract = new Bond("US064159KJ44");
-export const sample_index: Contract = new Index("ES", "USD");
-export const sample_dax_index: Contract = new Index("DAX", "EUR", "EUREX");
+export const sample_index: Contract = new Index("ES");
+export const sample_dax_index: Contract = new Index("DAX", "EUREX", "EUR");
 export const sample_crypto: Contract = new Crypto("BTC");
 
 // This one will need to be updated sometimes


### PR DESCRIPTION
### Motivation
- Make the `Crypto` contract class available from the package root so consumers can import it via the public API (`import { Crypto } from "@stoqey/ib"`).
- Fix the `Index` constructor parameter ordering which was inconsistent with other simple contract classes and caused incorrect usage in tests and examples.

### Description
- Exported `Crypto` from `src/index.ts` by adding `export { Crypto } from "./api/contract/crypto";`.
- Reordered the `Index` constructor parameters in `src/api/contract/ind.ts` to `constructor(symbol: string, exchange?: string, currency?: string)` and preserved the defaulting behavior (`currency` -> `USD`, `exchange` -> `CME`).
- Updated sample data in `src/tests/unit/sample-data/contracts.ts` to use the new `Index` argument order and to import `Crypto` from the public API.
- Added a targeted unit test `src/tests/unit/api/contract-api.test.ts` covering the `Crypto` export and the corrected `Index` constructor ordering, and created an AI changelog entry `.ai/changelogs/2026-06-16-contract-exports.md`.

### Testing
- Ran the new targeted test: `yarn jest src/tests/unit/api/contract-api.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`, and it passed (2 tests, 0 failures).
- Ran type checks with `yarn type-check`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30f138da188329abaa021896d220c3)