### PR TITLE
fix(api-next): allow distinct callbacks for same EventName in subscription registry

### DIFF
--- a/.ai/changelogs/2026-06-16-subscription-registry-callbacks.md
+++ b/.ai/changelogs/2026-06-16-subscription-registry-callbacks.md
@@ -1,0 +1,4 @@
+- summary: Allow api-next subscription registry to keep separate handlers for the same event when callbacks differ.
+- notable files or areas changed: `src/core/api-next/subscription-registry.ts`, `src/tests/unit/api-next/get-all-open-orders.test.ts`
+- tests run: `yarn jest src/tests/unit/api-next/get-all-open-orders.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`
+- risks or follow-ups: Existing local package manager file changes were left untouched.

--- a/src/core/api-next/subscription-registry.ts
+++ b/src/core/api-next/subscription-registry.ts
@@ -68,8 +68,8 @@ export class IBApiNextSubscriptionRegistry {
     private readonly apiNext: IBApiNext,
   ) {}
 
-  /** A Map containing the subscription registry, with event name as key. */
-  private readonly entries = new IBApiNextMap<EventName, RegistryEntry>();
+  /** A Map containing the subscription registry entries, grouped by event name. */
+  private readonly entries = new IBApiNextMap<EventName, RegistryEntry[]>();
 
   /**
    * Register a subscription.
@@ -101,15 +101,21 @@ export class IBApiNextSubscriptionRegistry {
     eventHandler.forEach((handler) => {
       const eventName = handler[0];
       const callback = handler[1];
-      const entry = this.entries.getOrAdd(eventName, () => {
-        const entry = new RegistryEntry(eventName, callback);
+      const eventEntries = this.entries.getOrAdd(eventName, () => []);
+      let entry = eventEntries.find(
+        (eventEntry) => eventEntry.callback === callback,
+      );
+
+      if (!entry) {
+        entry = new RegistryEntry(eventName, callback);
         this.apiNext.logger.debug(
           LOG_TAG,
           `Add RegistryEntry for EventName.${eventName}`,
         );
         this.api.addListener(eventName, entry.listener);
-        return entry;
-      });
+        eventEntries.push(entry);
+      }
+
       entries.push(entry);
     });
 
@@ -155,7 +161,14 @@ export class IBApiNextSubscriptionRegistry {
                 LOG_TAG,
                 `Remove RegistryEntry for EventName.${entry.eventName}.`,
               );
-              this.entries.delete(entry.eventName);
+              const eventEntries = this.entries.get(entry.eventName);
+              const entryIndex = eventEntries?.indexOf(entry) ?? -1;
+              if (entryIndex !== -1) {
+                eventEntries?.splice(entryIndex, 1);
+              }
+              if (!eventEntries?.length) {
+                this.entries.delete(entry.eventName);
+              }
             }
           });
 
@@ -185,8 +198,10 @@ export class IBApiNextSubscriptionRegistry {
    * Dispatch an error into the subscription that owns the given request id.
    */
   dispatchError(error: IBApiNextError): void {
-    this.entries.forEach((entry) => {
-      entry.subscriptions.get(error.reqId)?.error(error);
+    this.entries.forEach((eventEntries) => {
+      eventEntries.forEach((entry) => {
+        entry.subscriptions.get(error.reqId)?.error(error);
+      });
     });
   }
 }

--- a/src/tests/unit/api-next/get-all-open-orders.test.ts
+++ b/src/tests/unit/api-next/get-all-open-orders.test.ts
@@ -142,4 +142,24 @@ describe("RxJS Wrapper: getAllOpenOrders", () => {
     api.emit(EventName.openOrder, openOrders);
     api.emit(EventName.openOrderEnd);
   });
+
+  test("Promise result while getOpenOrders is subscribed", async () => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+    const openOrdersUpdates: unknown[] = [];
+
+    const openOrdersSubscription = apiNext.getOpenOrders().subscribe((data) => {
+      openOrdersUpdates.push(data);
+    });
+
+    const allOpenOrdersPromise = apiNext.getAllOpenOrders();
+
+    api.emit(EventName.openOrderEnd);
+
+    await expect(allOpenOrdersPromise).resolves.toEqual([]);
+    expect(openOrdersUpdates).toEqual([{ all: [], added: [] }]);
+
+    openOrdersSubscription.unsubscribe();
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Fix a bug where registering two active subscriptions that share the same `EventName` but use different callback handlers caused the second callback to be ignored. 
- Ensure the subscription registry can hold multiple registry entries per event when their callback references differ so concurrent APIs like `getOpenOrders()` and `getAllOpenOrders()` behave correctly.

### Description
- Change the registry storage to `IBApiNextMap<EventName, RegistryEntry[]>` so multiple `RegistryEntry` objects may be stored per event key. 
- When registering, look up an existing `RegistryEntry` by callback reference and reuse it only if identical; otherwise create a new `RegistryEntry` and attach a separate listener. 
- Update cleanup logic to remove the specific `RegistryEntry` from its event array and only delete the map key when the array becomes empty. 
- Update `dispatchError` to iterate nested entry arrays when routing errors. 
- Add a regression test (`src/tests/unit/api-next/get-all-open-orders.test.ts`) that asserts `getOpenOrders()` and `getAllOpenOrders()` can run concurrently and that `openOrderEnd` is handled correctly for both subscription callbacks. 
- Add an AI changelog entry under `.ai/changelogs/` documenting the change.

### Testing
- Ran the targeted unit tests with `yarn jest src/tests/unit/api-next/get-all-open-orders.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles` and all tests passed. 
- Ran type checking with `yarn type-check` which completed successfully. 
- Ran linter with `yarn lint`; lint completed (existing warnings remain in `src/api/api.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30f12975448329a4c7632c7b440821)