### PR TITLE
test(core): cover attached child order quantity

### DIFF
--- a/.ai/changelogs/2026-06-22-child-order-quantity.md
+++ b/.ai/changelogs/2026-06-22-child-order-quantity.md
@@ -1,0 +1,4 @@
+- summary: Added regression coverage that verifies attached child orders encode their own totalQuantity before transmit and parentId fields.
+- notable files or areas changed: src/tests/unit/core/io/encoder-place-order.test.ts
+- tests run: yarn jest src/tests/unit/core/io/encoder-place-order.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles
+- risks or follow-ups: This is protocol encoder coverage only; live TWS behavior can still depend on order type and attachment semantics.

--- a/src/tests/unit/core/io/encoder-place-order.test.ts
+++ b/src/tests/unit/core/io/encoder-place-order.test.ts
@@ -1,0 +1,44 @@
+import { Contract, Order, OrderAction, OrderType, SecType } from "../../../..";
+import MIN_SERVER_VER from "../../../../api/data/enum/min-server-version";
+import { Encoder, EncoderCallbacks } from "../../../../core/io/encoder";
+
+describe("Encoder placeOrder", () => {
+  test("encodes attached child order quantity independently from parent id", () => {
+    let sentTokens: unknown[] = [];
+    const callbacks: EncoderCallbacks = {
+      serverVersion: MIN_SERVER_VER.CME_TAGGING_FIELDS,
+      sendMsg: (...tokens: unknown[]) => {
+        sentTokens = tokens.flat(Infinity);
+      },
+      emitError: (message: string) => {
+        throw new Error(message);
+      },
+    };
+    const encoder = new Encoder(callbacks);
+    const contract: Contract = {
+      symbol: "SPY",
+      secType: SecType.STK,
+      exchange: "SMART",
+      currency: "USD",
+    };
+    const childOrder: Order = {
+      action: OrderAction.SELL,
+      totalQuantity: 1,
+      orderType: OrderType.LMT,
+      lmtPrice: 101.25,
+      tif: "GTC",
+      account: "DU123",
+      transmit: true,
+      parentId: 1000,
+    };
+
+    encoder.placeOrder(1001, contract, childOrder);
+
+    const actionIndex = sentTokens.indexOf(OrderAction.SELL);
+    expect(actionIndex).toBeGreaterThan(-1);
+    expect(sentTokens[actionIndex + 1]).toBe(1);
+    expect(sentTokens[actionIndex + 2]).toBe(OrderType.LMT);
+    expect(sentTokens[actionIndex + 11]).toBe(true);
+    expect(sentTokens[actionIndex + 12]).toBe(1000);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent regressions where an attached child order's `totalQuantity` could be mis-encoded or lost when `parentId` is set, which can make TWS show the full parent size instead of the child size. 
- Add a deterministic unit check of the protocol encoder to lock in the token ordering for `totalQuantity`, `transmit`, and `parentId` fields.

### Description
- Add `src/tests/unit/core/io/encoder-place-order.test.ts` which instantiates `Encoder` with a test `EncoderCallbacks` and asserts the encoded token positions for `action`, `totalQuantity`, `orderType`, `transmit`, and `parentId` for an attached child order.
- Add an AI changelog entry at `.ai/changelogs/2026-06-22-child-order-quantity.md` documenting the change, touched files, tests run, and follow-ups.

### Testing
- Ran the new test with `jest`: `npx --yes yarn@1.22.22 jest src/tests/unit/core/io/encoder-place-order.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles` and it passed.
- Ran type checking with `npx --yes yarn@1.22.22 type-check` and it passed.
- Ran lint with `npx --yes yarn@1.22.22 lint`; lint completed and reported pre-existing warnings but no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a389e0751208329988dc0ae5c583229)