### PR TITLE
fix(historicalDataUpdateDurations): fix historical update seed durations

### DIFF
--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -92,6 +92,33 @@ const LOG_TAG = "IBApiNext";
  */
 const TWS_LOG_TAG = "TWS";
 
+const historicalDataUpdateDurations: Partial<Record<BarSizeSetting, string>> = {
+  [BarSizeSetting.SECONDS_FIVE]: "60 S",
+  [BarSizeSetting.SECONDS_TEN]: "60 S",
+  [BarSizeSetting.SECONDS_FIFTEEN]: "60 S",
+  [BarSizeSetting.SECONDS_THIRTY]: "60 S",
+  [BarSizeSetting.MINUTES_ONE]: "60 S",
+  [BarSizeSetting.MINUTES_TWO]: "120 S",
+  [BarSizeSetting.MINUTES_THREE]: "1800 S",
+  [BarSizeSetting.MINUTES_FIVE]: "1800 S",
+  [BarSizeSetting.MINUTES_TEN]: "1800 S",
+  [BarSizeSetting.MINUTES_FIFTEEN]: "1800 S",
+  [BarSizeSetting.MINUTES_TWENTY]: "1800 S",
+  [BarSizeSetting.MINUTES_THIRTY]: "1800 S",
+  [BarSizeSetting.HOURS_ONE]: "3600 S",
+  [BarSizeSetting.HOURS_TWO]: "14400 S",
+  [BarSizeSetting.HOURS_THREE]: "14400 S",
+  [BarSizeSetting.HOURS_FOUR]: "28800 S",
+  [BarSizeSetting.HOURS_EIGHT]: "28800 S",
+  [BarSizeSetting.DAYS_ONE]: "1 D",
+  [BarSizeSetting.WEEKS_ONE]: "1 W",
+  [BarSizeSetting.MONTHS_ONE]: "1 M",
+};
+
+const getHistoricalDataUpdateDuration = (
+  barSizeSetting: BarSizeSetting,
+): string => historicalDataUpdateDurations[barSizeSetting] ?? "1 D";
+
 function filterMap(
   map: Map<number, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
   pred: (k: number, v: any) => boolean, // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -1850,8 +1877,7 @@ export class IBApiNext {
    * @see https://interactivebrokers.github.io/tws-api/historical_bars.html for details.
    *
    * @param contract The contract for which we want to retrieve the data.
-   * @param barSizeSetting the size of the bar:
-   * - 1 secs
+   * @param barSizeSetting the size of the bar. IB only supports keep-up-to-date historical bars for 5 seconds or greater:
    * - 5 secs
    * - 15 secs
    * - 30 secs
@@ -1888,7 +1914,7 @@ export class IBApiNext {
             reqId,
             contract,
             "",
-            "1 D",
+            getHistoricalDataUpdateDuration(barSizeSetting),
             barSizeSetting,
             whatToShow,
             0,

--- a/src/tests/unit/api-next/get-historical-data-updates.test.ts
+++ b/src/tests/unit/api-next/get-historical-data-updates.test.ts
@@ -13,6 +13,52 @@ import {
 import { BarSizeSetting } from "../../../api/historical/bar-size-setting";
 
 describe("RxJS Wrapper: getHistoricalDataUpdates()", () => {
+  test.each([
+    [BarSizeSetting.SECONDS_FIVE, "60 S"],
+    [BarSizeSetting.MINUTES_ONE, "60 S"],
+    [BarSizeSetting.MINUTES_TWO, "120 S"],
+    [BarSizeSetting.MINUTES_FIFTEEN, "1800 S"],
+    [BarSizeSetting.HOURS_ONE, "3600 S"],
+    [BarSizeSetting.HOURS_TWO, "14400 S"],
+    [BarSizeSetting.HOURS_EIGHT, "28800 S"],
+    [BarSizeSetting.DAYS_ONE, "1 D"],
+  ])(
+    "uses a compatible seed duration for %s bars",
+    (barSizeSetting, expectedDuration) => {
+      const apiNext = new IBApiNext();
+      const api = (apiNext as unknown as Record<string, unknown>)
+        .api as IBApi;
+      const reqHistoricalData = jest
+        .spyOn(api, "reqHistoricalData")
+        .mockReturnValue(api);
+
+      const subscription = apiNext
+        .getHistoricalDataUpdates({}, barSizeSetting, WhatToShow.TRADES, 1)
+        .subscribe({
+          error: (err: IBApiNextError) => {
+            fail(err.error.message);
+          },
+        });
+
+      api.emit(EventName.connected);
+
+      expect(reqHistoricalData).toHaveBeenCalledWith(
+        expect.any(Number),
+        {},
+        "",
+        expectedDuration,
+        barSizeSetting,
+        WhatToShow.TRADES,
+        0,
+        1,
+        true,
+      );
+
+      subscription.unsubscribe();
+      apiNext.disconnect();
+    },
+  );
+
   test("Observable updates", (done) => {
     // create IBApiNext
 


### PR DESCRIPTION
### Motivation

Follow-up from the review thread on #247: `getHistoricalDataUpdates` should avoid the slow `1 D` seed request for supported keep-up-to-date bar sizes, but a single hard-coded replacement is brittle.

Important nuance: IBKR historical backfill can use 1-second bars, but `keepUpToDate=true` historical update subscriptions are only documented for bar sizes `5 seconds` or greater. The method docs now reflect that floor.

### Description

- Added an internal duration lookup for `getHistoricalDataUpdates` keyed by `BarSizeSetting`.
- Uses shorter compatible seed durations for supported sub-day update bars, for example:
  - `5 secs` / `1 min` -> `60 S`
  - `2 mins` -> `120 S`
  - `15 mins` / `30 mins` -> `1800 S`
  - `1 hour` -> `3600 S`
  - `1 day` -> `1 D`
- Keeps `1 D` as the fallback for custom/unknown bar-size strings to preserve prior behavior.
- Updated the `getHistoricalDataUpdates` JSDoc to call out IBKR's `5 seconds or greater` `keepUpToDate` requirement.
- Added unit coverage that verifies the duration passed to `reqHistoricalData` for representative bar sizes.

### Local probe

Using paper TWS on `127.0.0.1:7497` with client id `45`:

- `60 S` worked for documented update bars from `5 secs` through `1 day`, so the exact #247 review concern about larger bars did not reproduce on this setup.
- `1 secs` did not produce a `keepUpToDate` update stream, which matches IBKR docs that `keepUpToDate` only supports `5 seconds` or greater.
- The rebuilt branch returned a live `IBApiNext.getHistoricalDataUpdates` update for ES Sep 2026 at `15 mins`.

### Testing

- `yarn jest src/tests/unit/api-next/get-historical-data-updates.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`
- `yarn type-check`
- `yarn lint` (passes with the existing warnings in `src/api/api.ts`)
- `yarn build`