### PR TITLE
fix(getRealTimeBars): add API-next realtime bars and tickString ticks

### DIFF
--- a/.ai/changelogs/2026-06-22-api-next-realtime-bars-tick-string.md
+++ b/.ai/changelogs/2026-06-22-api-next-realtime-bars-tick-string.md
@@ -1,0 +1,6 @@
+# API Next Realtime Bars And Tick String
+
+- summary: added `IBApiNext.getRealTimeBars` and raw `tickString` market data support.
+- notable files or areas changed: `src/api-next/api-next.ts`, `src/api-next/market/market-data.ts`, `src/tests/unit/api-next`.
+- tests run: `yarn jest src/tests/unit/api-next/get-market-data.test.ts src/tests/unit/api-next/get-real-time-bars.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`; `yarn type-check`; `yarn lint`; `yarn build`; live paper TWS probes against ES Sep 2026 for `getRealTimeBars` and `getMarketData(..., "233", false, false)`.
+- risks or follow-ups: live probe covered one ES futures contract; other instruments and market data permissions were not exhaustively probed.

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -1245,6 +1245,49 @@ export class IBApiNext {
     }
   };
 
+  /** tickString event handler */
+  private readonly onTickString = (
+    subscriptions: Map<number, IBApiNextSubscription<MutableMarketData>>,
+    reqId: number,
+    tickType: IBApiTickType,
+    value: string,
+  ): void => {
+    // get subscription
+
+    const subscription = subscriptions.get(reqId);
+    if (!subscription) {
+      return;
+    }
+
+    // update latest value on cache
+
+    const cached = subscription.lastAllValue ?? new MutableMarketData();
+    const hasChanged = cached.has(tickType);
+    const numericValue = value.trim() ? Number(value) : undefined;
+
+    const updatedValue: MarketDataTick = {
+      value: Number.isFinite(numericValue) ? numericValue : undefined,
+      stringValue: value,
+      ingressTm: Date.now(),
+    };
+
+    cached.set(tickType, updatedValue);
+
+    // deliver to subject
+
+    if (hasChanged) {
+      subscription.next({
+        all: cached,
+        changed: new MutableMarketData([[tickType, updatedValue]]),
+      });
+    } else {
+      subscription.next({
+        all: cached,
+        added: new MutableMarketData([[tickType, updatedValue]]),
+      });
+    }
+  };
+
   /** tickOptionComputationHandler event handler */
   private readonly onTickOptionComputation = (
     subscriptions: Map<number, IBApiNextSubscription<MutableMarketData>>,
@@ -1591,6 +1634,7 @@ export class IBApiNext {
         [EventName.tickPrice, this.onTick],
         [EventName.tickSize, this.onTick],
         [EventName.tickGeneric, this.onTick],
+        [EventName.tickString, this.onTickString],
         [EventName.tickOptionComputation, this.onTickOptionComputation],
         [EventName.tickSnapshotEnd, this.onTickSnapshotEnd],
       ],
@@ -3239,6 +3283,87 @@ export class IBApiNext {
         `${JSON.stringify(contract)}:${numberOfTicks}:${ignoreSize}`, // Use the same instance ID each time to ensure there is only one pending request at a time.
       )
       .pipe(map((v: { all: TickByTickAllLast }) => v.all));
+  }
+
+  /** realtimeBar event handler */
+  private readonly onRealTimeBar = (
+    subscriptions: Map<number, IBApiNextSubscription<Bar>>,
+    reqId: number,
+    time: number,
+    open: number,
+    high: number,
+    low: number,
+    close: number,
+    volume: number,
+    WAP: number,
+    count: number,
+  ): void => {
+    // get subscription
+
+    const subscription = subscriptions.get(reqId);
+    if (!subscription) {
+      return;
+    }
+
+    // update bar
+
+    const current: Bar = {
+      time: time.toString(),
+    };
+    if (open !== -1) {
+      current.open = open;
+    }
+    if (high !== -1) {
+      current.high = high;
+    }
+    if (low !== -1) {
+      current.low = low;
+    }
+    if (close !== -1) {
+      current.close = close;
+    }
+    if (volume !== -1) {
+      current.volume = volume;
+    }
+    if (WAP !== -1) {
+      current.WAP = WAP;
+    }
+    if (count !== -1) {
+      current.count = count;
+    }
+    subscription.next({ all: current });
+  };
+
+  /**
+   * Create a subscription to receive real-time 5-second bars.
+   *
+   * IB real-time bars are always aggregated server-side into 5-second bars.
+   *
+   * @param contract The contract for which we want to receive bars.
+   * @param whatToShow the kind of information being retrieved:
+   * - TRADES
+   * - MIDPOINT
+   * - BID
+   * - ASK
+   * @param useRTH Set to false to obtain the data which was also generated outside of the Regular Trading Hours, set to true to obtain only the RTH data.
+   */
+  getRealTimeBars(
+    contract: Contract,
+    whatToShow: WhatToShow = WhatToShow.TRADES,
+    useRTH: boolean = false,
+  ): Observable<Bar> {
+    return this.subscriptions
+      .register<Bar>(
+        (reqId) => {
+          this.api.reqRealTimeBars(reqId, contract, 5, whatToShow, useRTH);
+        },
+        (reqId) => {
+          this.api.cancelRealTimeBars(reqId);
+        },
+        [[EventName.realtimeBar, this.onRealTimeBar]],
+        `getRealTimeBars+${JSON.stringify(contract)}:${whatToShow}:${useRTH}`, // Use the same instance ID each time to ensure there is only one pending request at a time.
+      )
+      .pipe(map((v: { all: Bar }) => v.all));
   }
 
   private readonly onFundamentalData = (

--- a/src/api-next/market/market-data.ts
+++ b/src/api-next/market/market-data.ts
@@ -2,8 +2,11 @@ import { TickType, ItemListUpdate } from "../..";
 
 /**  A market data tick on [[IBApiNext]]. */
 export interface MarketDataTick {
-  /** The tick value. */
+  /** The numeric tick value. */
   readonly value?: number;
+
+  /** The raw string tick value, for ticks delivered through `tickString`. */
+  readonly stringValue?: string;
 
   /**
    * The ingress timestamp (UNIX) of the value.

--- a/src/tests/unit/api-next/get-market-data.test.ts
+++ b/src/tests/unit/api-next/get-market-data.test.ts
@@ -146,6 +146,86 @@ describe("RxJS Wrapper: getMarketData()", () => {
     api.emit(EventName.tickGeneric, 1, TickType.NEWS_TICK, testValue1);
   });
 
+  test("tickString numeric events", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    const testValue0 = "1718995200";
+    const testValue1 = "1718995205";
+
+    let received = 0;
+
+    const subscription = apiNext
+      .getMarketData({ conId: 12345 }, null, false, false)
+      .subscribe({
+        next: (data) => {
+          if (received == 0) {
+            expect(data.added).toBeDefined();
+            expect(data.changed).toBeUndefined();
+            expect(data.added.get(TickType.LAST_TIMESTAMP).value).toEqual(
+              Number(testValue0),
+            );
+          } else {
+            expect(data.added).toBeUndefined();
+            expect(data.changed).toBeDefined();
+            expect(data.changed.get(TickType.LAST_TIMESTAMP).value).toEqual(
+              Number(testValue1),
+            );
+          }
+          expect(data.all.get(TickType.LAST_TIMESTAMP).value).toEqual(
+            Number(received ? testValue1 : testValue0),
+          );
+          expect(data.all.get(TickType.LAST_TIMESTAMP).stringValue).toEqual(
+            received ? testValue1 : testValue0,
+          );
+          expect(data.all.get(TickType.LAST_TIMESTAMP).ingressTm).toEqual(
+            expect.any(Number),
+          );
+          received++;
+          if (received == 2) {
+            subscription.unsubscribe();
+            done();
+          }
+        },
+        error: (error: IBApiNextError) => {
+          fail(error.error.message);
+        },
+      });
+
+    api.emit(EventName.tickString, 1, TickType.LAST_TIMESTAMP, testValue0);
+    api.emit(EventName.tickString, 1, TickType.LAST_TIMESTAMP, testValue1);
+  });
+
+  test("tickString structured events", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    const rtVolume = "184.84;2;1718995200000;100;184.80;true";
+
+    const subscription = apiNext
+      .getMarketData({ conId: 12345 }, "233", false, false)
+      .subscribe({
+        next: (data) => {
+          expect(data.added).toBeDefined();
+          expect(data.changed).toBeUndefined();
+          expect(data.all.get(TickType.RT_VOLUME).value).toBeUndefined();
+          expect(data.all.get(TickType.RT_VOLUME).stringValue).toEqual(
+            rtVolume,
+          );
+          expect(data.added.get(TickType.RT_VOLUME).stringValue).toEqual(
+            rtVolume,
+          );
+          subscription.unsubscribe();
+          done();
+        },
+        error: (error: IBApiNextError) => {
+          fail(error.error.message);
+        },
+      });
+
+    api.emit(EventName.tickString, 1, TickType.RT_VOLUME, rtVolume);
+  });
+
   test("tickOptionComputationHandler events", (done) => {
     const apiNext = new IBApiNext();
     const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;

--- a/src/tests/unit/api-next/get-real-time-bars.test.ts
+++ b/src/tests/unit/api-next/get-real-time-bars.test.ts
@@ -1,0 +1,108 @@
+/**
+ * This file implements tests for the [[IBApiNext.getRealTimeBars]] function.
+ */
+
+import { Bar, EventName, IBApi, IBApiNext, IBApiNextError } from "../../..";
+import { WhatToShow } from "../../../api/historical/what-to-show";
+
+describe("RxJS Wrapper: getRealTimeBars()", () => {
+  test("requests fixed five second bars and cancels on unsubscribe", () => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+    const contract = { conId: 12345 };
+    const reqRealTimeBars = jest
+      .spyOn(api, "reqRealTimeBars")
+      .mockReturnValue(api);
+    const cancelRealTimeBars = jest
+      .spyOn(api, "cancelRealTimeBars")
+      .mockReturnValue(api);
+    jest.spyOn(api, "isConnected", "get").mockReturnValue(true);
+
+    const subscription = apiNext.getRealTimeBars(contract).subscribe({
+      error: (err: IBApiNextError) => {
+        fail(err.error.message);
+      },
+    });
+
+    api.emit(EventName.connected);
+
+    expect(reqRealTimeBars).toHaveBeenCalledWith(
+      expect.any(Number),
+      contract,
+      5,
+      WhatToShow.TRADES,
+      false,
+    );
+
+    subscription.unsubscribe();
+
+    expect(cancelRealTimeBars).toHaveBeenCalledWith(
+      reqRealTimeBars.mock.calls[0][0],
+    );
+  });
+
+  test("emits realtimeBar events as bars", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+    const refBar: Bar = {
+      time: "1718995200",
+      open: 1,
+      high: 2,
+      low: 3,
+      close: 4,
+      volume: 5,
+      WAP: 6,
+      count: 7,
+    };
+
+    const subscription = apiNext
+      .getRealTimeBars({ conId: 12345 }, WhatToShow.BID, true)
+      .subscribe({
+        next: (bar) => {
+          expect(bar).toEqual(refBar);
+          subscription.unsubscribe();
+          done();
+        },
+        error: (err: IBApiNextError) => {
+          fail(err.error.message);
+        },
+      });
+
+    api.emit(
+      EventName.realtimeBar,
+      1,
+      Number(refBar.time),
+      refBar.open,
+      refBar.high,
+      refBar.low,
+      refBar.close,
+      refBar.volume,
+      refBar.WAP,
+      refBar.count,
+    );
+  });
+
+  test("omits unavailable realtimeBar fields", (done) => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+
+    const subscription = apiNext.getRealTimeBars({ conId: 12345 }).subscribe({
+      next: (bar) => {
+        expect(bar).toEqual({
+          time: "1718995200",
+          open: 1,
+          high: 2,
+          low: 3,
+          close: 4,
+        });
+        subscription.unsubscribe();
+        done();
+      },
+      error: (err: IBApiNextError) => {
+        fail(err.error.message);
+      },
+    });
+
+    api.emit(EventName.realtimeBar, 1, 1718995200, 1, 2, 3, 4, -1, -1, -1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `IBApiNext.getRealTimeBars(...)` as an Observable wrapper over `reqRealTimeBars`, including unsubscribe cancellation.
- Add `tickString` handling to `IBApiNext.getMarketData(...)`.
- Preserve numeric `MarketDataTick.value` and add `MarketDataTick.stringValue` for raw tick string payloads such as RTVolume.
- Add deterministic API-next unit tests and AI changelog notes.

## Tests

- `yarn jest src/tests/unit/api-next/get-market-data.test.ts src/tests/unit/api-next/get-real-time-bars.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`
- `yarn type-check`
- `yarn lint` (passes with existing warnings in `src/api/api.ts`)
- `yarn build`
- Live paper TWS probe at `127.0.0.1:7497`, client id `45`, ES Sep 2026 future:
  - `getRealTimeBars(contract, WhatToShow.TRADES, false)` emitted a 5-second bar.
  - `getMarketData(contract, "233", false, false)` emitted `tickString` type `45` (`LAST_TIMESTAMP`) with numeric `value` and raw `stringValue`.
  - `getMarketData(contract, "233", false, false)` emitted `tickString` type `48` (`RT_VOLUME`) with the structured semicolon-delimited payload preserved in `stringValue`.

## Risks / Follow-ups

- Live probe covered one ES futures contract; other instruments and market data permission combinations were not exhaustively probed.