### PR TITLE
[codex] Complete open orders snapshot

### DIFF
--- a/.ai/changelogs/2026-06-23-open-orders-completion.md
+++ b/.ai/changelogs/2026-06-23-open-orders-completion.md
@@ -1,0 +1,4 @@
+- summary: complete `IBApiNext.getOpenOrders()` on `openOrderEnd` while keeping `getAutoOpenOrders()` subscribed for future updates.
+- notable files or areas changed: `src/api-next/api-next.ts`, `src/tests/unit/api-next/get-all-open-orders.test.ts`.
+- tests run: `yarn jest src/tests/unit/api-next/get-all-open-orders.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`; `yarn jest src/tests/unit/api-next-live/subscription-registry.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`; `yarn type-check`; `yarn lint`.
+- risks or follow-ups: live verification depends on paper TWS availability.

--- a/src/api-next/api-next.ts
+++ b/src/api-next/api-next.ts
@@ -2863,7 +2863,7 @@ export class IBApiNext {
         [EventName.openOrder, this.onOpenOrder],
         [EventName.orderStatus, this.onOrderStatus],
         [EventName.orderBound, this.onOrderBound],
-        [EventName.openOrderEnd, this.onOpenOrderEnd],
+        [EventName.openOrderEnd, this.onOpenOrderComplete],
       ],
       "getOpenOrders", // Use the same instance ID each time to ensure there is only one pending request at a time.
     );

--- a/src/tests/unit/api-next/get-all-open-orders.test.ts
+++ b/src/tests/unit/api-next/get-all-open-orders.test.ts
@@ -147,9 +147,15 @@ describe("RxJS Wrapper: getAllOpenOrders", () => {
     const apiNext = new IBApiNext();
     const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
     const openOrdersUpdates: unknown[] = [];
+    let getOpenOrdersCompleted = false;
 
-    const openOrdersSubscription = apiNext.getOpenOrders().subscribe((data) => {
-      openOrdersUpdates.push(data);
+    apiNext.getOpenOrders().subscribe({
+      next: (data) => {
+        openOrdersUpdates.push(data);
+      },
+      complete: () => {
+        getOpenOrdersCompleted = true;
+      },
     });
 
     const allOpenOrdersPromise = apiNext.getAllOpenOrders();
@@ -158,8 +164,30 @@ describe("RxJS Wrapper: getAllOpenOrders", () => {
 
     await expect(allOpenOrdersPromise).resolves.toEqual([]);
     expect(openOrdersUpdates).toEqual([{ all: [], added: [] }]);
+    expect(getOpenOrdersCompleted).toEqual(true);
+  });
 
-    openOrdersSubscription.unsubscribe();
+  test("getAutoOpenOrders stays subscribed after openOrderEnd", () => {
+    const apiNext = new IBApiNext();
+    const api = (apiNext as unknown as Record<string, unknown>).api as IBApi;
+    const autoOpenOrdersUpdates: unknown[] = [];
+    let autoOpenOrdersCompleted = false;
+
+    const subscription = apiNext.getAutoOpenOrders(false).subscribe({
+      next: (data) => {
+        autoOpenOrdersUpdates.push(data);
+      },
+      complete: () => {
+        autoOpenOrdersCompleted = true;
+      },
+    });
+
+    api.emit(EventName.openOrderEnd);
+
+    expect(autoOpenOrdersUpdates).toEqual([{ all: [], added: [] }]);
+    expect(autoOpenOrdersCompleted).toEqual(false);
+
+    subscription.unsubscribe();
   });
 
 });


### PR DESCRIPTION
## Summary

- Complete `IBApiNext.getOpenOrders()` when `openOrderEnd` arrives, matching the one-shot `reqOpenOrders()` behavior.
- Keep `IBApiNext.getAutoOpenOrders()` on the non-completing handler so future TWS order updates can continue streaming.
- Extend the deterministic open-orders regression test to cover both lifecycles.

## Root Cause

PR #265 fixed the subscription registry bug where two active subscriptions shared the same `EventName` but needed distinct callbacks. The remaining failing live test was a separate lifecycle issue: `getOpenOrders()` emitted on `openOrderEnd` but did not complete, so the test waited forever for `done()`.

## Tests

- `yarn jest src/tests/unit/api-next/get-all-open-orders.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`
- `yarn jest src/tests/unit/api-next-live/subscription-registry.test.ts --runInBand --reporters=default --useStderr --detectOpenHandles`
- `yarn type-check`
- `yarn lint` (passes with existing warnings in `src/api/api.ts`)

## Risks / Follow-ups

- `getOpenOrders()` now behaves as a one-shot snapshot Observable. `getAutoOpenOrders()` remains the streaming future-order update path.